### PR TITLE
feat(auth): implement Supabase authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,13 @@ Minavolve is an Agile sprint board product concept with room for an AI assistant
 - App Router route structure for `/`, `/login`, `/register`, and `/dashboard`
 - Shared product copy in `src/lib/site.ts`
 - Reusable marketing components for the landing page
-- Placeholder auth and dashboard pages with intentional styling
+- Supabase email/password login, registration, logout, and protected dashboard access
 - Starter environment variable documentation in `.env.example`
 - Initial Supabase schema migration for projects, sprints, stories, risks, AI generations, activity, memberships, and profiles
 
 ## What is intentionally not implemented yet
 
-- No Supabase client integration or frontend database calls
-- No real authentication or session handling
+- No project CRUD or sprint CRUD
 - No drag-and-drop board behavior
 - No AI API routes or provider integration
 
@@ -77,14 +76,38 @@ npm run lint
 
 ## Environment variables
 
-The app does not consume external services yet, but `.env.example` documents the variables planned for upcoming issues:
+Copy `.env.example` to `.env.local` and provide the Supabase cloud project values:
 
 - `NEXT_PUBLIC_APP_URL`
 - `NEXT_PUBLIC_SUPABASE_URL`
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
-- `SUPABASE_SERVICE_ROLE_KEY`
+
+AI provider variables remain placeholders for later issues:
+
 - `OPENAI_API_KEY`
 - `ANTHROPIC_API_KEY`
+
+## Supabase Auth setup
+
+Issue #6 adds Supabase email/password authentication using `@supabase/ssr`. The app does not use `@supabase/auth-helpers-nextjs`.
+
+### Configure Supabase Cloud
+
+1. Confirm the Issue #2 SQL schema has already been applied.
+2. In the Supabase dashboard, go to `Authentication > Providers`.
+3. Enable the `Email` provider.
+4. Choose whether email confirmation is required.
+5. In `Authentication > URL Configuration`, set the site URL to the deployed app URL. For local development, use `http://localhost:3000`.
+6. Add local and deployed redirect URLs as needed, starting with `http://localhost:3000/**`.
+
+### Auth behavior
+
+- `/` remains public.
+- `/login` signs users in with Supabase Auth and redirects authenticated users to `/dashboard`.
+- `/register` creates a Supabase Auth user. If email confirmation is disabled, the new user is redirected to `/dashboard`; if confirmation is enabled, the page sends the user back to login with a check-your-email message.
+- `/dashboard` verifies the user on the server with `supabase.auth.getUser()` and redirects unauthenticated users to `/login`.
+- The dashboard shows the authenticated user's email and includes a logout form.
+- `middleware.ts` refreshes Supabase auth cookies through the `@supabase/ssr` server client.
 
 ## Supabase database setup
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,13 @@
+import type { NextRequest } from "next/server";
+
+import { updateSession } from "@/utils/supabase/middleware";
+
+export async function middleware(request: NextRequest) {
+  return updateSession(request);
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)$).*)",
+  ],
+};

--- a/src/app/(app)/dashboard/actions.ts
+++ b/src/app/(app)/dashboard/actions.ts
@@ -1,0 +1,12 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+import { createClient } from "@/utils/supabase/server";
+
+export async function logout() {
+  const supabase = await createClient();
+  await supabase.auth.signOut();
+
+  redirect("/login?message=You%20have%20been%20signed%20out.");
+}

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,23 +1,36 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import {
-  ArrowLeft,
   Bot,
   CheckCircle2,
   Clock3,
   LayoutDashboard,
+  LogOut,
+  ShieldCheck,
   Sparkles,
 } from "lucide-react";
+import { redirect } from "next/navigation";
 
+import { logout } from "@/app/(app)/dashboard/actions";
 import { Button } from "@/components/ui/button";
 import { roadmapItems, sprintBoardPreview } from "@/lib/site";
+import { createClient } from "@/utils/supabase/server";
 
 export const metadata: Metadata = {
   title: "Dashboard",
-  description: "Placeholder dashboard route for the Minavolve app foundation.",
+  description: "Protected dashboard route for Minavolve.",
 };
 
-export default function DashboardPage() {
+export default async function DashboardPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
   return (
     <main className="min-h-screen px-4 py-8 sm:px-6 lg:px-8">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">
@@ -29,36 +42,38 @@ export default function DashboardPage() {
               </div>
               <div>
                 <p className="text-sm font-medium uppercase tracking-[0.24em] text-brand">
-                  Dashboard placeholder
+                  Authenticated dashboard
                 </p>
                 <h1 className="mt-2 font-heading text-3xl font-semibold text-slate-950">
                   Sprint board shell
                 </h1>
                 <p className="mt-2 max-w-2xl text-base leading-7 text-slate-700">
-                  This route is intentionally non-authenticated and static for
-                  now. It demonstrates the future workspace layout without
-                  shipping data persistence, permissions, or drag-and-drop
-                  behavior yet.
+                  You are signed in as{" "}
+                  <span className="font-semibold text-slate-950">
+                    {user.email}
+                  </span>
+                  . Project, sprint, and Kanban data will be added in later
+                  issues.
                 </p>
               </div>
             </div>
 
             <div className="flex flex-col gap-3 sm:flex-row">
-              <Button
-                disabled
-                size="lg"
-                className="rounded-full px-6"
-              >
-                AI actions later
-              </Button>
-              <Button
-                asChild
-                size="lg"
-                variant="outline"
-                className="rounded-full border-slate-300 bg-white"
-              >
-                <Link href="/">Back to landing page</Link>
-              </Button>
+              <div className="inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-emerald-50 px-4 py-2 text-sm font-medium text-emerald-800">
+                <ShieldCheck className="size-4" />
+                Session verified
+              </div>
+              <form action={logout}>
+                <Button
+                  type="submit"
+                  size="lg"
+                  variant="outline"
+                  className="w-full rounded-full border-slate-300 bg-white px-6 sm:w-auto"
+                >
+                  <LogOut className="size-4" />
+                  Logout
+                </Button>
+              </form>
             </div>
           </div>
         </header>
@@ -76,10 +91,10 @@ export default function DashboardPage() {
               </div>
               <div className="flex flex-wrap gap-2 text-sm">
                 <span className="rounded-full bg-brand-soft px-3 py-1.5 text-brand">
-                  4 columns
+                  Static preview
                 </span>
                 <span className="rounded-full bg-amber-100 px-3 py-1.5 text-amber-900">
-                  Placeholder cards
+                  CRUD later
                 </span>
               </div>
             </div>
@@ -130,16 +145,15 @@ export default function DashboardPage() {
                 <Bot className="size-5 text-cyan-300" />
               </div>
               <p className="mt-3 text-sm leading-7 text-slate-300">
-                The future AI surface will live here. For now, this card marks
-                the dedicated UI area for summaries, sprint risk prompts, and
-                planning suggestions.
+                The future AI surface remains a placeholder. Authentication is
+                now in place; AI API calls are still intentionally out of scope.
               </p>
 
               <div className="mt-6 space-y-3">
                 {[
-                  "Summarize standup updates",
-                  "Draft sprint review notes",
-                  "Highlight tasks that may slip",
+                  "Supabase session refresh is active",
+                  "Dashboard access requires a verified user",
+                  "Logout clears the Supabase Auth session",
                 ].map((item) => (
                   <div
                     key={item}
@@ -188,11 +202,10 @@ export default function DashboardPage() {
         </section>
 
         <Link
-          href="/login"
+          href="/"
           className="inline-flex items-center gap-2 text-sm text-slate-600 transition-colors hover:text-slate-950"
         >
-          <ArrowLeft className="size-4" />
-          Open auth placeholder routes
+          Back to public landing page
         </Link>
       </div>
     </main>

--- a/src/app/(auth)/login/actions.ts
+++ b/src/app/(auth)/login/actions.ts
@@ -1,0 +1,57 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+import { createClient } from "@/utils/supabase/server";
+
+function getString(formData: FormData, key: string) {
+  const value = formData.get(key);
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function redirectWithError(message: string): never {
+  redirect(`/login?error=${encodeURIComponent(message)}`);
+}
+
+function getLoginErrorMessage(message: string, status?: number) {
+  const normalized = message.toLowerCase();
+
+  if (
+    status === 429 ||
+    normalized.includes("rate limit") ||
+    normalized.includes("security purposes")
+  ) {
+    return "Too many sign-in attempts. Wait a few minutes and try again.";
+  }
+
+  if (normalized.includes("invalid login credentials")) {
+    return "The email or password is incorrect.";
+  }
+
+  if (normalized.includes("email not confirmed")) {
+    return "Please confirm your email before signing in.";
+  }
+
+  return "Unable to sign in. Check your details and try again.";
+}
+
+export async function login(formData: FormData) {
+  const email = getString(formData, "email").toLowerCase();
+  const password = getString(formData, "password");
+
+  if (!email || !password) {
+    redirectWithError("Enter both your email and password.");
+  }
+
+  const supabase = await createClient();
+  const { error } = await supabase.auth.signInWithPassword({
+    email,
+    password,
+  });
+
+  if (error) {
+    redirectWithError(getLoginErrorMessage(error.message, error.status));
+  }
+
+  redirect("/dashboard");
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,42 +1,70 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowLeft, Lock, Sparkles } from "lucide-react";
+import {
+  AlertCircle,
+  ArrowLeft,
+  CheckCircle2,
+  KeyRound,
+  Lock,
+  Mail,
+} from "lucide-react";
+import { redirect } from "next/navigation";
 
+import { login } from "@/app/(auth)/login/actions";
 import { Button } from "@/components/ui/button";
 import { siteConfig } from "@/lib/site";
+import { createClient } from "@/utils/supabase/server";
 
 export const metadata: Metadata = {
   title: "Login",
-  description: "Placeholder login route for the Minavolve app foundation.",
+  description: "Sign in to Minavolve with Supabase Auth.",
 };
 
-export default function LoginPage() {
+type LoginPageProps = {
+  searchParams: Promise<{
+    error?: string;
+    message?: string;
+  }>;
+};
+
+export default async function LoginPage({ searchParams }: LoginPageProps) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (user) {
+    redirect("/dashboard");
+  }
+
+  const params = await searchParams;
+
   return (
     <main className="relative flex min-h-screen items-center justify-center overflow-hidden px-4 py-14 sm:px-6 lg:px-8">
       <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top_left,_rgba(8,145,178,0.18),_transparent_30%),radial-gradient(circle_at_bottom_right,_rgba(249,115,22,0.12),_transparent_28%)]" />
 
-      <div className="grid w-full max-w-5xl gap-6 lg:grid-cols-[0.88fr_1.12fr]">
+      <div className="grid w-full max-w-5xl gap-6 lg:grid-cols-[0.9fr_1.1fr]">
         <section className="rounded-[2rem] bg-slate-950 p-8 text-slate-50 shadow-[0_30px_80px_-45px_rgba(15,23,42,0.95)]">
           <div className="inline-flex size-12 items-center justify-center rounded-2xl bg-white/10">
             <Lock className="size-6" />
           </div>
           <p className="mt-6 text-sm font-medium uppercase tracking-[0.24em] text-cyan-300">
-            Authentication placeholder
+            {siteConfig.name}
           </p>
           <h1 className="mt-4 font-heading text-4xl font-semibold">
-            Login route is ready for real auth wiring.
+            Sign in to your sprint workspace.
           </h1>
           <p className="mt-4 text-base leading-7 text-slate-300">
-            This page gives the future sign-in experience a visual home without
-            introducing sessions, providers, or database dependencies in this
-            issue.
+            Email and password authentication is handled by Supabase Auth.
+            Project data stays protected behind authenticated routes and RLS
+            policies.
           </p>
 
           <div className="mt-8 space-y-3 text-sm text-slate-200">
             {[
-              "Supabase auth integration will land in a later issue.",
-              "Credential handling and validation are intentionally absent here.",
-              "The route already exists, so future auth logic has a clean entry point.",
+              "Sessions are refreshed by the Supabase SSR middleware.",
+              "The dashboard verifies the user on the server before rendering.",
+              "Registration creates the Supabase Auth user; the database trigger creates the profile.",
             ].map((item) => (
               <div
                 key={item}
@@ -49,55 +77,64 @@ export default function LoginPage() {
         </section>
 
         <section className="rounded-[2rem] border border-white/70 bg-white/85 p-8 shadow-[0_30px_90px_-55px_rgba(15,23,42,0.6)] backdrop-blur">
-          <div className="inline-flex items-center gap-2 rounded-full bg-brand-soft px-3 py-1.5 text-sm font-medium text-brand">
-            <Sparkles className="size-4" />
-            {siteConfig.name}
-          </div>
-          <h2 className="mt-5 font-heading text-3xl font-semibold text-slate-950">
-            Sign in placeholder
+          <h2 className="font-heading text-3xl font-semibold text-slate-950">
+            Welcome back
           </h2>
           <p className="mt-3 text-base leading-7 text-slate-700">
-            Use this route for the future email/password or provider-based login
-            flow. Inputs are intentionally disabled until auth is implemented.
+            Enter the email and password for your Minavolve account.
           </p>
 
-          <div className="mt-8 space-y-5">
+          {params.error ? (
+            <div className="mt-6 flex gap-3 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm leading-6 text-red-800">
+              <AlertCircle className="mt-0.5 size-4 shrink-0" />
+              <p>{params.error}</p>
+            </div>
+          ) : null}
+
+          {params.message ? (
+            <div className="mt-6 flex gap-3 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm leading-6 text-emerald-800">
+              <CheckCircle2 className="mt-0.5 size-4 shrink-0" />
+              <p>{params.message}</p>
+            </div>
+          ) : null}
+
+          <form action={login} className="mt-8 space-y-5">
             <label className="block text-sm font-medium text-slate-800">
               Email
-              <input
-                disabled
-                type="email"
-                placeholder="you@team.com"
-                className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-500 outline-none disabled:cursor-not-allowed disabled:opacity-100"
-              />
+              <span className="relative mt-2 block">
+                <Mail className="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-slate-400" />
+                <input
+                  required
+                  autoComplete="email"
+                  type="email"
+                  name="email"
+                  placeholder="you@team.com"
+                  className="h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-11 text-sm text-slate-900 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+                />
+              </span>
             </label>
 
             <label className="block text-sm font-medium text-slate-800">
               Password
-              <input
-                disabled
-                type="password"
-                placeholder="********"
-                className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-500 outline-none disabled:cursor-not-allowed disabled:opacity-100"
-              />
+              <span className="relative mt-2 block">
+                <KeyRound className="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-slate-400" />
+                <input
+                  required
+                  autoComplete="current-password"
+                  type="password"
+                  name="password"
+                  placeholder="********"
+                  className="h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-11 text-sm text-slate-900 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+                />
+              </span>
             </label>
-          </div>
 
-          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-            <Button disabled size="lg" className="rounded-full px-6">
-              Auth coming soon
+            <Button type="submit" size="lg" className="w-full rounded-full">
+              Sign in
             </Button>
-            <Button
-              asChild
-              size="lg"
-              variant="outline"
-              className="rounded-full border-slate-300 bg-white"
-            >
-              <Link href="/register">Open register</Link>
-            </Button>
-          </div>
+          </form>
 
-          <div className="mt-8 flex flex-wrap gap-3 text-sm">
+          <div className="mt-8 flex flex-wrap items-center justify-between gap-3 text-sm">
             <Link
               href="/"
               className="inline-flex items-center gap-2 text-slate-600 transition-colors hover:text-slate-950"
@@ -106,10 +143,10 @@ export default function LoginPage() {
               Back to landing page
             </Link>
             <Link
-              href="/dashboard"
-              className="inline-flex items-center gap-2 text-slate-600 transition-colors hover:text-slate-950"
+              href="/register"
+              className="font-medium text-brand transition-colors hover:text-slate-950"
             >
-              Jump to dashboard placeholder
+              Create an account
             </Link>
           </div>
         </section>

--- a/src/app/(auth)/register/actions.ts
+++ b/src/app/(auth)/register/actions.ts
@@ -1,0 +1,88 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+import { createClient } from "@/utils/supabase/server";
+
+function getString(formData: FormData, key: string) {
+  const value = formData.get(key);
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function redirectWithError(message: string): never {
+  redirect(`/register?error=${encodeURIComponent(message)}`);
+}
+
+function getRegisterErrorMessage(message: string, status?: number) {
+  const normalized = message.toLowerCase();
+
+  if (
+    status === 429 ||
+    normalized.includes("rate limit") ||
+    normalized.includes("security purposes")
+  ) {
+    return "Too many signup attempts. Wait a few minutes and try again.";
+  }
+
+  if (normalized.includes("invalid") && normalized.includes("email")) {
+    return "Enter a valid email address.";
+  }
+
+  if (normalized.includes("already registered")) {
+    return "That email is already registered. Try signing in instead.";
+  }
+
+  if (normalized.includes("password")) {
+    return "Use a stronger password. It must be at least 8 characters.";
+  }
+
+  return "Unable to create your account. Check your details and try again.";
+}
+
+export async function register(formData: FormData) {
+  const fullName = getString(formData, "fullName");
+  const email = getString(formData, "email").toLowerCase();
+  const password = getString(formData, "password");
+  const confirmPassword = getString(formData, "confirmPassword");
+
+  if (fullName.length < 2) {
+    redirectWithError("Enter your full name.");
+  }
+
+  if (!email || !password || !confirmPassword) {
+    redirectWithError("Enter your email and password.");
+  }
+
+  if (password.length < 8) {
+    redirectWithError("Password must be at least 8 characters.");
+  }
+
+  if (password !== confirmPassword) {
+    redirectWithError("Passwords do not match.");
+  }
+
+  const supabase = await createClient();
+  const { data, error } = await supabase.auth.signUp({
+    email,
+    password,
+    options: {
+      data: {
+        full_name: fullName,
+      },
+    },
+  });
+
+  if (error) {
+    redirectWithError(getRegisterErrorMessage(error.message, error.status));
+  }
+
+  if (data.session) {
+    redirect("/dashboard");
+  }
+
+  redirect(
+    `/login?message=${encodeURIComponent(
+      "Check your email to confirm your account before signing in.",
+    )}`,
+  );
+}

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -1,16 +1,48 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowLeft, Sparkles, UserPlus } from "lucide-react";
+import {
+  AlertCircle,
+  ArrowLeft,
+  CheckCircle2,
+  KeyRound,
+  Mail,
+  Sparkles,
+  User,
+  UserPlus,
+} from "lucide-react";
+import { redirect } from "next/navigation";
 
+import { register } from "@/app/(auth)/register/actions";
 import { Button } from "@/components/ui/button";
 import { siteConfig } from "@/lib/site";
+import { createClient } from "@/utils/supabase/server";
 
 export const metadata: Metadata = {
   title: "Register",
-  description: "Placeholder registration route for the Minavolve app foundation.",
+  description: "Create a Minavolve account with Supabase Auth.",
 };
 
-export default function RegisterPage() {
+type RegisterPageProps = {
+  searchParams: Promise<{
+    error?: string;
+    message?: string;
+  }>;
+};
+
+export default async function RegisterPage({
+  searchParams,
+}: RegisterPageProps) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (user) {
+    redirect("/dashboard");
+  }
+
+  const params = await searchParams;
+
   return (
     <main className="relative flex min-h-screen items-center justify-center overflow-hidden px-4 py-14 sm:px-6 lg:px-8">
       <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top_right,_rgba(249,115,22,0.16),_transparent_28%),radial-gradient(circle_at_bottom_left,_rgba(8,145,178,0.16),_transparent_32%)]" />
@@ -19,74 +51,115 @@ export default function RegisterPage() {
         <section className="rounded-[2rem] border border-white/70 bg-white/85 p-8 shadow-[0_30px_90px_-55px_rgba(15,23,42,0.6)] backdrop-blur">
           <div className="inline-flex items-center gap-2 rounded-full bg-brand-soft px-3 py-1.5 text-sm font-medium text-brand">
             <Sparkles className="size-4" />
-            Build the workspace later
+            Start with email and password
           </div>
           <h1 className="mt-5 font-heading text-4xl font-semibold text-slate-950">
-            Registration route is scaffolded and ready for onboarding logic.
+            Create your Minavolve account.
           </h1>
           <p className="mt-4 text-base leading-7 text-slate-700">
-            This screen reserves the future account creation flow while keeping
-            the current issue focused on routing, copy, and visual foundation.
+            Registration uses Supabase Auth. If email confirmation is enabled,
+            you will need to confirm your inbox before signing in.
           </p>
 
-          <div className="mt-8 grid gap-5 sm:grid-cols-2">
+          {params.error ? (
+            <div className="mt-6 flex gap-3 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm leading-6 text-red-800">
+              <AlertCircle className="mt-0.5 size-4 shrink-0" />
+              <p>{params.error}</p>
+            </div>
+          ) : null}
+
+          {params.message ? (
+            <div className="mt-6 flex gap-3 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm leading-6 text-emerald-800">
+              <CheckCircle2 className="mt-0.5 size-4 shrink-0" />
+              <p>{params.message}</p>
+            </div>
+          ) : null}
+
+          <form action={register} className="mt-8 space-y-5">
             <label className="block text-sm font-medium text-slate-800">
               Full name
-              <input
-                disabled
-                type="text"
-                placeholder="Alex Johnson"
-                className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-500 outline-none disabled:cursor-not-allowed disabled:opacity-100"
-              />
+              <span className="relative mt-2 block">
+                <User className="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-slate-400" />
+                <input
+                  required
+                  autoComplete="name"
+                  type="text"
+                  name="fullName"
+                  placeholder="Alex Johnson"
+                  className="h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-11 text-sm text-slate-900 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+                />
+              </span>
             </label>
 
             <label className="block text-sm font-medium text-slate-800">
-              Team email
-              <input
-                disabled
-                type="email"
-                placeholder="alex@minavolve.app"
-                className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-500 outline-none disabled:cursor-not-allowed disabled:opacity-100"
-              />
+              Email
+              <span className="relative mt-2 block">
+                <Mail className="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-slate-400" />
+                <input
+                  required
+                  autoComplete="email"
+                  type="email"
+                  name="email"
+                  placeholder="alex@minavolve.app"
+                  className="h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-11 text-sm text-slate-900 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+                />
+              </span>
             </label>
-          </div>
 
-          <label className="mt-5 block text-sm font-medium text-slate-800">
-            Workspace name
-            <input
-              disabled
-              type="text"
-              placeholder="Launch Week Sprint Board"
-              className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-500 outline-none disabled:cursor-not-allowed disabled:opacity-100"
-            />
-          </label>
+            <div className="grid gap-5 sm:grid-cols-2">
+              <label className="block text-sm font-medium text-slate-800">
+                Password
+                <span className="relative mt-2 block">
+                  <KeyRound className="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-slate-400" />
+                  <input
+                    required
+                    autoComplete="new-password"
+                    type="password"
+                    name="password"
+                    minLength={8}
+                    placeholder="8+ characters"
+                    className="h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-11 text-sm text-slate-900 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+                  />
+                </span>
+              </label>
 
-          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-            <Button disabled size="lg" className="rounded-full px-6">
-              Account creation later
+              <label className="block text-sm font-medium text-slate-800">
+                Confirm password
+                <span className="relative mt-2 block">
+                  <KeyRound className="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-slate-400" />
+                  <input
+                    required
+                    autoComplete="new-password"
+                    type="password"
+                    name="confirmPassword"
+                    minLength={8}
+                    placeholder="Repeat password"
+                    className="h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-11 text-sm text-slate-900 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+                  />
+                </span>
+              </label>
+            </div>
+
+            <Button type="submit" size="lg" className="w-full rounded-full">
+              Create account
             </Button>
-            <Button
-              asChild
-              size="lg"
-              variant="outline"
-              className="rounded-full border-slate-300 bg-white"
+          </form>
+
+          <div className="mt-8 flex flex-wrap items-center justify-between gap-3 text-sm">
+            <Link
+              href="/"
+              className="inline-flex items-center gap-2 text-slate-600 transition-colors hover:text-slate-950"
             >
-              <Link href="/login">Open login</Link>
-            </Button>
+              <ArrowLeft className="size-4" />
+              Back to landing page
+            </Link>
+            <Link
+              href="/login"
+              className="font-medium text-brand transition-colors hover:text-slate-950"
+            >
+              Already have an account?
+            </Link>
           </div>
-
-          <p className="mt-6 text-sm leading-7 text-slate-600">
-            Planned next steps: Supabase auth, onboarding flows, team creation,
-            and protected dashboard access.
-          </p>
-
-          <Link
-            href="/"
-            className="mt-6 inline-flex items-center gap-2 text-sm text-slate-600 transition-colors hover:text-slate-950"
-          >
-            <ArrowLeft className="size-4" />
-            Back to landing page
-          </Link>
         </section>
 
         <section className="rounded-[2rem] bg-slate-950 p-8 text-slate-50 shadow-[0_30px_80px_-45px_rgba(15,23,42,0.95)]">
@@ -97,19 +170,18 @@ export default function RegisterPage() {
             {siteConfig.name}
           </p>
           <h2 className="mt-4 font-heading text-3xl font-semibold">
-            A deliberate route shell beats a rushed auth form.
+            Your profile is created by the database trigger.
           </h2>
           <p className="mt-4 text-base leading-7 text-slate-300">
-            Keeping registration as a placeholder avoids fake behavior while the
-            real account model, permissions, and session strategy are still
-            being defined.
+            Supabase Auth creates the account, then the Issue #2 trigger creates
+            the matching `public.profiles` row automatically.
           </p>
 
           <div className="mt-8 space-y-3 text-sm text-slate-200">
             {[
-              "Route grouping keeps auth pages organized without changing the URL.",
-              "Shared branding and copy already match the dashboard shell.",
-              "Future onboarding can plug into this screen without a design reset.",
+              "No project setup happens during registration yet.",
+              "Email confirmation depends on the Supabase Auth project settings.",
+              "After sign-in, the dashboard reads the verified user server-side.",
             ].map((item) => (
               <div
                 key={item}

--- a/src/utils/supabase/client.ts
+++ b/src/utils/supabase/client.ts
@@ -1,0 +1,25 @@
+import { createBrowserClient } from "@supabase/ssr";
+
+function getSupabaseUrl() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+  if (!supabaseUrl) {
+    throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL");
+  }
+
+  return supabaseUrl;
+}
+
+function getSupabaseAnonKey() {
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseAnonKey) {
+    throw new Error("Missing NEXT_PUBLIC_SUPABASE_ANON_KEY");
+  }
+
+  return supabaseAnonKey;
+}
+
+export function createClient() {
+  return createBrowserClient(getSupabaseUrl(), getSupabaseAnonKey());
+}

--- a/src/utils/supabase/middleware.ts
+++ b/src/utils/supabase/middleware.ts
@@ -1,0 +1,57 @@
+import { createServerClient } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from "next/server";
+
+function getSupabaseUrl() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+  if (!supabaseUrl) {
+    throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL");
+  }
+
+  return supabaseUrl;
+}
+
+function getSupabaseAnonKey() {
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseAnonKey) {
+    throw new Error("Missing NEXT_PUBLIC_SUPABASE_ANON_KEY");
+  }
+
+  return supabaseAnonKey;
+}
+
+export async function updateSession(request: NextRequest) {
+  let supabaseResponse = NextResponse.next({
+    request,
+  });
+
+  const supabase = createServerClient(getSupabaseUrl(), getSupabaseAnonKey(), {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet, headers) {
+        cookiesToSet.forEach(({ name, value }) => {
+          request.cookies.set(name, value);
+        });
+
+        supabaseResponse = NextResponse.next({
+          request,
+        });
+
+        cookiesToSet.forEach(({ name, value, options }) => {
+          supabaseResponse.cookies.set(name, value, options);
+        });
+
+        Object.entries(headers).forEach(([key, value]) => {
+          supabaseResponse.headers.set(key, value);
+        });
+      },
+    },
+  });
+
+  await supabase.auth.getUser();
+
+  return supabaseResponse;
+}

--- a/src/utils/supabase/server.ts
+++ b/src/utils/supabase/server.ts
@@ -1,0 +1,43 @@
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+
+function getSupabaseUrl() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+  if (!supabaseUrl) {
+    throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL");
+  }
+
+  return supabaseUrl;
+}
+
+function getSupabaseAnonKey() {
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseAnonKey) {
+    throw new Error("Missing NEXT_PUBLIC_SUPABASE_ANON_KEY");
+  }
+
+  return supabaseAnonKey;
+}
+
+export async function createClient() {
+  const cookieStore = await cookies();
+
+  return createServerClient(getSupabaseUrl(), getSupabaseAnonKey(), {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      setAll(cookiesToSet) {
+        try {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            cookieStore.set(name, value, options);
+          });
+        } catch {
+          // Server Components cannot set cookies. Middleware refreshes sessions.
+        }
+      },
+    },
+  });
+}


### PR DESCRIPTION
## Summary

This PR implements Supabase authentication for Minavolve.

## Changes

- Added Supabase browser client utility
- Added Supabase server client utility
- Added Supabase middleware session handling
- Added app middleware for auth session refresh
- Replaced login placeholder with working login form
- Replaced register placeholder with working registration form
- Added server actions for login, registration, and logout
- Protected `/dashboard`
- Displayed authenticated user email on dashboard
- Updated README with Supabase Auth setup instructions

## Testing

- Ran `npm run lint`
- Ran `npm run dev`
- Registered a test user through `/register`
- Confirmed user appears in Supabase Authentication
- Confirmed profile row appears in `public.profiles`
- Logged in through `/login`
- Confirmed authenticated user can access `/dashboard`
- Confirmed logout works
- Confirmed logged-out users are redirected away from `/dashboard`

Closes Issue #6 