### PR TITLE
feat(dashboard): add authenticated dashboard layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Minavolve
 
-Minavolve is an Agile sprint board product concept with room for an AI assistant. This repository currently ships the visual foundation: a polished landing page, placeholder authentication routes, and a dashboard shell that later issues can connect to Supabase, drag-and-drop interactions, and AI workflows.
+Minavolve is an Agile sprint board product concept with room for an AI assistant. This repository currently ships a polished landing page, Supabase email/password authentication, and an authenticated dashboard layout that later issues can connect to project data, drag-and-drop interactions, and AI workflows.
 
 ## What this issue includes
 
@@ -9,6 +9,7 @@ Minavolve is an Agile sprint board product concept with room for an AI assistant
 - Shared product copy in `src/lib/site.ts`
 - Reusable marketing components for the landing page
 - Supabase email/password login, registration, logout, and protected dashboard access
+- Authenticated dashboard layout with sidebar navigation, top bar, static summary metrics, placeholder work sections, and a five-column Kanban preview
 - Starter environment variable documentation in `.env.example`
 - Initial Supabase schema migration for projects, sprints, stories, risks, AI generations, activity, memberships, and profiles
 
@@ -70,9 +71,21 @@ npm run lint
 ## Route guide
 
 - `/`: product landing page for Minavolve
-- `/login`: placeholder sign-in screen
-- `/register`: placeholder account creation screen
-- `/dashboard`: placeholder sprint board shell
+- `/login`: Supabase email/password sign-in screen
+- `/register`: Supabase email/password account creation screen
+- `/dashboard`: protected authenticated dashboard shell with static layout data
+
+## Dashboard status
+
+Issue #8 adds the authenticated dashboard shell. The page keeps the existing server-side Supabase user check, shows the signed-in user's email in the top bar, and keeps logout wired through the dashboard server action.
+
+Current dashboard content is intentionally static:
+
+- Summary cards for projects, active sprints, user stories, and open risks
+- Placeholder sections for recent projects, sprint planning, Kanban preview, risk register, delivery analytics, and AI assistant
+- A visual Kanban preview with Backlog, To Do, In Progress, Review, and Done columns
+
+Real project queries, sprint CRUD, story management, drag-and-drop, charts, and AI provider calls remain out of scope for this issue.
 
 ## Environment variables
 

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,24 +1,25 @@
 import type { Metadata } from "next";
-import Link from "next/link";
-import {
-  Bot,
-  CheckCircle2,
-  Clock3,
-  LayoutDashboard,
-  LogOut,
-  ShieldCheck,
-  Sparkles,
-} from "lucide-react";
 import { redirect } from "next/navigation";
 
 import { logout } from "@/app/(app)/dashboard/actions";
-import { Button } from "@/components/ui/button";
-import { roadmapItems, sprintBoardPreview } from "@/lib/site";
+import { AppSidebar } from "@/components/app/app-sidebar";
+import { AppTopbar } from "@/components/app/app-topbar";
+import { DashboardCard } from "@/components/app/dashboard-card";
+import { DashboardSection } from "@/components/app/dashboard-section";
+import { KanbanPreview } from "@/components/app/kanban-preview";
+import {
+  analyticsHighlights,
+  assistantPrompts,
+  dashboardSummaryCards,
+  recentProjects,
+  riskRegisterItems,
+  sprintPlanningItems,
+} from "@/lib/dashboard";
 import { createClient } from "@/utils/supabase/server";
 
 export const metadata: Metadata = {
   title: "Dashboard",
-  description: "Protected dashboard route for Minavolve.",
+  description: "Authenticated Minavolve dashboard layout.",
 };
 
 export default async function DashboardPage() {
@@ -31,182 +32,205 @@ export default async function DashboardPage() {
     redirect("/login");
   }
 
+  const userEmail = user.email ?? "Authenticated user";
+
   return (
-    <main className="min-h-screen px-4 py-8 sm:px-6 lg:px-8">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">
-        <header className="rounded-[2rem] border border-white/70 bg-white/80 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.7)] backdrop-blur sm:p-6">
-          <div className="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
-            <div className="flex items-start gap-4">
-              <div className="inline-flex size-12 items-center justify-center rounded-2xl bg-slate-950 text-slate-50">
-                <LayoutDashboard className="size-6" />
-              </div>
-              <div>
-                <p className="text-sm font-medium uppercase tracking-[0.24em] text-brand">
-                  Authenticated dashboard
-                </p>
-                <h1 className="mt-2 font-heading text-3xl font-semibold text-slate-950">
-                  Sprint board shell
-                </h1>
-                <p className="mt-2 max-w-2xl text-base leading-7 text-slate-700">
-                  You are signed in as{" "}
-                  <span className="font-semibold text-slate-950">
-                    {user.email}
+    <main className="min-h-screen px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto flex w-full max-w-[1540px] flex-col gap-6 lg:flex-row">
+        <div className="lg:w-72 lg:shrink-0">
+          <AppSidebar />
+        </div>
+
+        <div className="min-w-0 flex-1 space-y-6">
+          <AppTopbar userEmail={userEmail} onLogout={logout} />
+
+          <section
+            className="grid gap-4 md:grid-cols-2 xl:grid-cols-4"
+            aria-label="Dashboard summary"
+          >
+            {dashboardSummaryCards.map((card) => (
+              <DashboardCard
+                key={card.label}
+                label={card.label}
+                value={card.value}
+                detail={card.detail}
+                trend={card.trend}
+                tone={card.tone}
+                Icon={card.Icon}
+              />
+            ))}
+          </section>
+
+          <div className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr)_minmax(360px,0.75fr)]">
+            <div className="space-y-6">
+              <DashboardSection
+                id="recent-projects"
+                eyebrow="Portfolio"
+                title="Recent projects"
+                description="Static project rows provide the dashboard shape before Supabase project queries are connected."
+                action={
+                  <span className="rounded-full bg-brand-soft px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-brand">
+                    Placeholder data
                   </span>
-                  . Project, sprint, and Kanban data will be added in later
-                  issues.
-                </p>
-              </div>
-            </div>
-
-            <div className="flex flex-col gap-3 sm:flex-row">
-              <div className="inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-emerald-50 px-4 py-2 text-sm font-medium text-emerald-800">
-                <ShieldCheck className="size-4" />
-                Session verified
-              </div>
-              <form action={logout}>
-                <Button
-                  type="submit"
-                  size="lg"
-                  variant="outline"
-                  className="w-full rounded-full border-slate-300 bg-white px-6 sm:w-auto"
-                >
-                  <LogOut className="size-4" />
-                  Logout
-                </Button>
-              </form>
-            </div>
-          </div>
-        </header>
-
-        <section className="grid gap-6 xl:grid-cols-[1.45fr_0.75fr]">
-          <div className="rounded-[2rem] border border-white/70 bg-white/80 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.7)] backdrop-blur sm:p-6">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-              <div>
-                <p className="text-sm font-medium text-slate-600">
-                  Current sprint
-                </p>
-                <h2 className="mt-1 font-heading text-2xl font-semibold text-slate-950">
-                  Launch Week
-                </h2>
-              </div>
-              <div className="flex flex-wrap gap-2 text-sm">
-                <span className="rounded-full bg-brand-soft px-3 py-1.5 text-brand">
-                  Static preview
-                </span>
-                <span className="rounded-full bg-amber-100 px-3 py-1.5 text-amber-900">
-                  CRUD later
-                </span>
-              </div>
-            </div>
-
-            <div className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-              {sprintBoardPreview.map((column) => (
-                <section
-                  key={column.title}
-                  className="rounded-[1.5rem] border border-slate-200 bg-slate-50/90 p-4"
-                >
-                  <div className="flex items-center justify-between gap-3">
-                    <h3 className="font-heading text-lg font-semibold text-slate-900">
-                      {column.title}
-                    </h3>
-                    <span
-                      className={`rounded-full px-2.5 py-1 text-xs font-medium ${column.badgeClass}`}
+                }
+              >
+                <div className="grid gap-3">
+                  {recentProjects.map((project) => (
+                    <article
+                      key={project.code}
+                      className="grid gap-4 rounded-[1.5rem] border border-slate-200 bg-slate-50/80 p-4 md:grid-cols-[0.65fr_1fr_auto]"
                     >
-                      {column.status}
-                    </span>
-                  </div>
+                      <div className="flex items-center gap-3">
+                        <div className="inline-flex size-11 shrink-0 items-center justify-center rounded-2xl bg-slate-950 font-heading text-sm font-semibold text-white">
+                          {project.code}
+                        </div>
+                        <div>
+                          <h3 className="font-semibold text-slate-950">
+                            {project.name}
+                          </h3>
+                          <p className="text-sm text-slate-500">
+                            {project.status}
+                          </p>
+                        </div>
+                      </div>
+                      <p className="text-sm leading-6 text-slate-600">
+                        {project.focus}
+                      </p>
+                      <span className="h-fit rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1.5 text-sm font-semibold text-emerald-800">
+                        {project.health}
+                      </span>
+                    </article>
+                  ))}
+                </div>
+              </DashboardSection>
 
-                  <div className="mt-4 space-y-3">
-                    {column.cards.map((card) => (
-                      <article
-                        key={card.title}
-                        className="rounded-[1.25rem] border border-white bg-white p-4 shadow-[0_14px_40px_-32px_rgba(15,23,42,0.7)]"
-                      >
-                        <p className="font-medium text-slate-900">
-                          {card.title}
+              <DashboardSection
+                id="sprint-planning"
+                eyebrow="Planning"
+                title="Sprint planning"
+                description="A non-interactive planning snapshot for scope, capacity, and review readiness."
+              >
+                <div className="grid gap-4 md:grid-cols-3">
+                  {sprintPlanningItems.map((item) => (
+                    <article
+                      key={item.label}
+                      className="rounded-[1.5rem] border border-slate-200 bg-white p-4"
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <h3 className="font-semibold text-slate-950">
+                          {item.label}
+                        </h3>
+                        <span className="font-mono text-sm text-brand">
+                          {item.progress}
+                        </span>
+                      </div>
+                      <div className="mt-4 h-2 rounded-full bg-slate-100">
+                        <div
+                          className="h-full rounded-full bg-brand"
+                          style={{ width: item.progress }}
+                        />
+                      </div>
+                      <p className="mt-4 text-sm leading-6 text-slate-600">
+                        {item.detail}
+                      </p>
+                    </article>
+                  ))}
+                </div>
+              </DashboardSection>
+
+              <DashboardSection
+                id="kanban-preview"
+                eyebrow="Board"
+                title="Kanban preview"
+                description="The board is intentionally static in this issue. Drag-and-drop and persistence come later."
+              >
+                <KanbanPreview />
+              </DashboardSection>
+            </div>
+
+            <div className="space-y-6">
+              <DashboardSection
+                id="risk-register"
+                eyebrow="Risk"
+                title="Risk register"
+                description="Delivery risks are mocked until project and activity data are available."
+              >
+                <div className="space-y-3">
+                  {riskRegisterItems.map((risk) => (
+                    <article
+                      key={risk.label}
+                      className="rounded-[1.5rem] border border-slate-200 bg-slate-50/80 p-4"
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <span className="rounded-full bg-rose-100 px-3 py-1 text-xs font-semibold text-rose-700">
+                          {risk.severity}
+                        </span>
+                        <span className="text-xs font-medium text-slate-500">
+                          {risk.owner}
+                        </span>
+                      </div>
+                      <p className="mt-3 text-sm leading-6 text-slate-700">
+                        {risk.label}
+                      </p>
+                    </article>
+                  ))}
+                </div>
+              </DashboardSection>
+
+              <DashboardSection
+                id="delivery-analytics"
+                eyebrow="Analytics"
+                title="Delivery analytics"
+                description="Charting is out of scope, so this section uses static KPI tiles only."
+              >
+                <div className="grid gap-3">
+                  {analyticsHighlights.map((item) => (
+                    <article
+                      key={item.label}
+                      className="rounded-[1.5rem] border border-slate-200 bg-white p-4"
+                    >
+                      <div className="flex items-baseline justify-between gap-4">
+                        <h3 className="font-semibold text-slate-700">
+                          {item.label}
+                        </h3>
+                        <p className="font-heading text-3xl font-semibold text-slate-950">
+                          {item.value}
                         </p>
-                        <p className="mt-2 text-sm leading-6 text-slate-600">
-                          {card.meta}
-                        </p>
-                      </article>
-                    ))}
-                  </div>
-                </section>
-              ))}
+                      </div>
+                      <p className="mt-2 text-sm leading-6 text-slate-600">
+                        {item.detail}
+                      </p>
+                    </article>
+                  ))}
+                </div>
+              </DashboardSection>
+
+              <DashboardSection
+                id="ai-assistant"
+                eyebrow="Assistant"
+                title="AI assistant"
+                description="The UI reserves space for AI workflows without creating API routes or provider calls."
+                dark
+              >
+                <div className="space-y-3">
+                  {assistantPrompts.map((prompt) => (
+                    <article
+                      key={prompt.label}
+                      className="rounded-[1.5rem] border border-white/10 bg-white/[0.06] p-4"
+                    >
+                      <p className="font-semibold text-white">
+                        {prompt.label}
+                      </p>
+                      <p className="mt-2 text-sm leading-6 text-slate-300">
+                        {prompt.detail}
+                      </p>
+                    </article>
+                  ))}
+                </div>
+              </DashboardSection>
             </div>
           </div>
-
-          <div className="grid gap-6">
-            <section className="rounded-[2rem] bg-slate-950 p-6 text-slate-50 shadow-[0_25px_70px_-45px_rgba(15,23,42,0.95)]">
-              <div className="flex items-center justify-between gap-3">
-                <h2 className="font-heading text-2xl font-semibold">
-                  Assistant panel
-                </h2>
-                <Bot className="size-5 text-cyan-300" />
-              </div>
-              <p className="mt-3 text-sm leading-7 text-slate-300">
-                The future AI surface remains a placeholder. Authentication is
-                now in place; AI API calls are still intentionally out of scope.
-              </p>
-
-              <div className="mt-6 space-y-3">
-                {[
-                  "Supabase session refresh is active",
-                  "Dashboard access requires a verified user",
-                  "Logout clears the Supabase Auth session",
-                ].map((item) => (
-                  <div
-                    key={item}
-                    className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-slate-200"
-                  >
-                    {item}
-                  </div>
-                ))}
-              </div>
-            </section>
-
-            <section className="rounded-[2rem] border border-white/70 bg-white/80 p-6 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.7)] backdrop-blur">
-              <div className="flex items-center gap-3">
-                <Sparkles className="size-5 text-brand" />
-                <h2 className="font-heading text-2xl font-semibold text-slate-950">
-                  Next implementation slices
-                </h2>
-              </div>
-
-              <div className="mt-5 space-y-4">
-                {roadmapItems.map((item, index) => (
-                  <article
-                    key={item.label}
-                    className="rounded-[1.5rem] border border-slate-200 bg-slate-50 px-4 py-4"
-                  >
-                    <div className="flex items-center gap-3">
-                      <div className="inline-flex size-9 items-center justify-center rounded-2xl bg-brand-soft text-brand">
-                        {index === 0 ? (
-                          <CheckCircle2 className="size-4" />
-                        ) : (
-                          <Clock3 className="size-4" />
-                        )}
-                      </div>
-                      <h3 className="font-medium text-slate-900">
-                        {item.label}
-                      </h3>
-                    </div>
-                    <p className="mt-3 text-sm leading-6 text-slate-600">
-                      {item.detail}
-                    </p>
-                  </article>
-                ))}
-              </div>
-            </section>
-          </div>
-        </section>
-
-        <Link
-          href="/"
-          className="inline-flex items-center gap-2 text-sm text-slate-600 transition-colors hover:text-slate-950"
-        >
-          Back to public landing page
-        </Link>
+        </div>
       </div>
     </main>
   );

--- a/src/components/app/app-sidebar.tsx
+++ b/src/components/app/app-sidebar.tsx
@@ -1,0 +1,81 @@
+import Link from "next/link";
+import { ArrowUpRight, Boxes, ChevronRight } from "lucide-react";
+
+import { dashboardFocusItems, dashboardNavItems } from "@/lib/dashboard";
+import { siteConfig } from "@/lib/site";
+import { cn } from "@/lib/utils";
+
+export function AppSidebar() {
+  return (
+    <aside className="lg:sticky lg:top-6 lg:h-[calc(100vh-3rem)]">
+      <div className="flex h-full flex-col rounded-[2rem] border border-white/80 bg-slate-950 p-4 text-slate-50 shadow-[0_32px_90px_-55px_rgba(15,23,42,0.95)] sm:p-5">
+        <Link href="/" className="flex items-center gap-3 rounded-3xl p-2">
+          <div className="inline-flex size-11 items-center justify-center rounded-2xl bg-brand text-brand-foreground">
+            <Boxes className="size-5" />
+          </div>
+          <div>
+            <p className="font-heading text-xl font-semibold">
+              {siteConfig.name}
+            </p>
+            <p className="text-xs text-slate-400">Sprint operations</p>
+          </div>
+        </Link>
+
+        <nav className="mt-7 space-y-1" aria-label="Dashboard navigation">
+          {dashboardNavItems.map((item) => (
+            <Link
+              key={item.label}
+              href={item.href}
+              aria-current={item.active ? "page" : undefined}
+              className={cn(
+                "group flex items-center justify-between rounded-2xl px-3 py-3 text-sm font-medium transition-colors",
+                item.active
+                  ? "bg-white text-slate-950"
+                  : "text-slate-300 hover:bg-white/10 hover:text-white",
+              )}
+            >
+              <span className="flex items-center gap-3">
+                <item.Icon className="size-4" />
+                {item.label}
+              </span>
+              {item.active ? (
+                <ChevronRight className="size-4 text-brand" />
+              ) : null}
+            </Link>
+          ))}
+        </nav>
+
+        <div className="mt-7 rounded-[1.5rem] border border-white/10 bg-white/[0.06] p-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-200">
+            Issue #8 scope
+          </p>
+          <div className="mt-4 space-y-4">
+            {dashboardFocusItems.map((item) => (
+              <div key={item.label} className="flex gap-3">
+                <div className="mt-0.5 inline-flex size-8 shrink-0 items-center justify-center rounded-xl bg-white/10 text-cyan-200">
+                  <item.Icon className="size-4" />
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-white">
+                    {item.label}
+                  </p>
+                  <p className="mt-1 text-xs leading-5 text-slate-400">
+                    {item.detail}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <Link
+          href="/"
+          className="mt-4 inline-flex items-center justify-between rounded-2xl border border-white/10 px-4 py-3 text-sm text-slate-300 transition-colors hover:border-white/20 hover:text-white lg:mt-auto"
+        >
+          Public landing page
+          <ArrowUpRight className="size-4" />
+        </Link>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/app/app-topbar.tsx
+++ b/src/components/app/app-topbar.tsx
@@ -1,0 +1,70 @@
+import { Bell, LogOut, Search, ShieldCheck } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+type AppTopbarProps = {
+  userEmail: string;
+  onLogout: () => Promise<void>;
+};
+
+export function AppTopbar({ userEmail, onLogout }: AppTopbarProps) {
+  return (
+    <header className="rounded-[2rem] border border-white/80 bg-white/86 p-4 shadow-[0_24px_80px_-58px_rgba(15,23,42,0.72)] backdrop-blur">
+      <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-brand">
+            Authenticated workspace
+          </p>
+          <h1 className="mt-2 font-heading text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+            Delivery command center
+          </h1>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+            Static dashboard shell for sprint planning, board visibility, risk
+            review, analytics, and future AI assistance.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <div className="flex min-w-0 items-center gap-3 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+            <Search className="size-4 shrink-0 text-slate-400" />
+            <span className="truncate">Search projects later</span>
+          </div>
+
+          <div className="flex min-w-0 items-center gap-3 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3">
+            <ShieldCheck className="size-4 shrink-0 text-emerald-700" />
+            <div className="min-w-0">
+              <p className="text-xs font-medium text-emerald-800">
+                Signed in
+              </p>
+              <p className="truncate text-sm font-semibold text-emerald-950">
+                {userEmail}
+              </p>
+            </div>
+          </div>
+
+          <Button
+            type="button"
+            size="icon-lg"
+            variant="outline"
+            className="hidden rounded-2xl border-slate-200 bg-white text-slate-600 xl:inline-flex"
+            aria-label="Notifications placeholder"
+          >
+            <Bell className="size-4" />
+          </Button>
+
+          <form action={onLogout}>
+            <Button
+              type="submit"
+              size="lg"
+              variant="outline"
+              className="w-full rounded-2xl border-slate-300 bg-white px-4 text-slate-700 hover:text-slate-950 sm:w-auto"
+            >
+              <LogOut className="size-4" />
+              Logout
+            </Button>
+          </form>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/app/dashboard-card.tsx
+++ b/src/components/app/dashboard-card.tsx
@@ -1,0 +1,86 @@
+import type { LucideIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export type DashboardCardTone = "blue" | "green" | "amber" | "rose";
+
+const toneClasses: Record<
+  DashboardCardTone,
+  {
+    card: string;
+    icon: string;
+    trend: string;
+  }
+> = {
+  blue: {
+    card: "from-blue-50 to-white",
+    icon: "bg-blue-100 text-blue-700",
+    trend: "text-blue-700",
+  },
+  green: {
+    card: "from-emerald-50 to-white",
+    icon: "bg-emerald-100 text-emerald-700",
+    trend: "text-emerald-700",
+  },
+  amber: {
+    card: "from-amber-50 to-white",
+    icon: "bg-amber-100 text-amber-800",
+    trend: "text-amber-800",
+  },
+  rose: {
+    card: "from-rose-50 to-white",
+    icon: "bg-rose-100 text-rose-700",
+    trend: "text-rose-700",
+  },
+};
+
+type DashboardCardProps = {
+  label: string;
+  value: string;
+  detail: string;
+  trend: string;
+  tone: DashboardCardTone;
+  Icon: LucideIcon;
+};
+
+export function DashboardCard({
+  label,
+  value,
+  detail,
+  trend,
+  tone,
+  Icon,
+}: DashboardCardProps) {
+  const classes = toneClasses[tone];
+
+  return (
+    <article
+      className={cn(
+        "group rounded-[1.75rem] border border-white/80 bg-gradient-to-br p-5 shadow-[0_24px_70px_-50px_rgba(15,23,42,0.65)] transition-transform duration-300 hover:-translate-y-1",
+        classes.card,
+      )}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-sm font-medium text-slate-500">{label}</p>
+          <p className="mt-3 font-heading text-4xl font-semibold tracking-tight text-slate-950">
+            {value}
+          </p>
+        </div>
+        <div
+          className={cn(
+            "inline-flex size-11 items-center justify-center rounded-2xl",
+            classes.icon,
+          )}
+        >
+          <Icon className="size-5" />
+        </div>
+      </div>
+
+      <p className="mt-4 text-sm leading-6 text-slate-600">{detail}</p>
+      <p className={cn("mt-4 text-sm font-semibold", classes.trend)}>
+        {trend}
+      </p>
+    </article>
+  );
+}

--- a/src/components/app/dashboard-section.tsx
+++ b/src/components/app/dashboard-section.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+type DashboardSectionProps = {
+  id?: string;
+  eyebrow?: string;
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  children: ReactNode;
+  className?: string;
+  contentClassName?: string;
+  dark?: boolean;
+};
+
+export function DashboardSection({
+  id,
+  eyebrow,
+  title,
+  description,
+  action,
+  children,
+  className,
+  contentClassName,
+  dark = false,
+}: DashboardSectionProps) {
+  return (
+    <section
+      id={id}
+      className={cn(
+        "rounded-[2rem] border p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6",
+        dark
+          ? "border-slate-800 bg-slate-950 text-slate-50"
+          : "border-white/80 bg-white/82 text-slate-950",
+        className,
+      )}
+    >
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          {eyebrow ? (
+            <p
+              className={cn(
+                "text-xs font-semibold uppercase tracking-[0.24em]",
+                dark ? "text-cyan-200" : "text-brand",
+              )}
+            >
+              {eyebrow}
+            </p>
+          ) : null}
+          <h2 className="mt-2 font-heading text-2xl font-semibold tracking-tight">
+            {title}
+          </h2>
+          {description ? (
+            <p
+              className={cn(
+                "mt-2 max-w-2xl text-sm leading-6",
+                dark ? "text-slate-300" : "text-slate-600",
+              )}
+            >
+              {description}
+            </p>
+          ) : null}
+        </div>
+        {action ? <div className="shrink-0">{action}</div> : null}
+      </div>
+
+      <div className={cn("mt-6", contentClassName)}>{children}</div>
+    </section>
+  );
+}

--- a/src/components/app/kanban-preview.tsx
+++ b/src/components/app/kanban-preview.tsx
@@ -1,0 +1,52 @@
+import { kanbanColumns } from "@/lib/dashboard";
+import { cn } from "@/lib/utils";
+
+export function KanbanPreview() {
+  return (
+    <div className="overflow-x-auto pb-2">
+      <div className="grid min-w-[980px] grid-cols-5 gap-4">
+        {kanbanColumns.map((column) => (
+          <section
+            key={column.title}
+            className="rounded-[1.5rem] border border-slate-200 bg-slate-50/90 p-3"
+          >
+            <div className="flex items-center justify-between gap-3 px-1">
+              <h3 className="font-heading text-lg font-semibold text-slate-950">
+                {column.title}
+              </h3>
+              <span
+                className={cn(
+                  "rounded-full px-2.5 py-1 text-xs font-semibold",
+                  column.accentClass,
+                )}
+              >
+                {column.count}
+              </span>
+            </div>
+
+            <div className="mt-4 space-y-3">
+              {column.cards.map((card) => (
+                <article
+                  key={card.title}
+                  className="rounded-[1.25rem] border border-white bg-white p-4 shadow-[0_18px_45px_-34px_rgba(15,23,42,0.75)]"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <p className="font-medium leading-6 text-slate-950">
+                      {card.title}
+                    </p>
+                    <span className="rounded-full bg-slate-100 px-2 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-slate-500">
+                      {card.tag}
+                    </span>
+                  </div>
+                  <p className="mt-3 text-sm leading-6 text-slate-600">
+                    {card.meta}
+                  </p>
+                </article>
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/dashboard.ts
+++ b/src/lib/dashboard.ts
@@ -1,0 +1,348 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  BarChart3,
+  Bot,
+  CircleDot,
+  ClipboardList,
+  FolderKanban,
+  Gauge,
+  LayoutDashboard,
+  ListChecks,
+  MessageSquareText,
+  ShieldAlert,
+  Sparkles,
+  TimerReset,
+} from "lucide-react";
+
+export type DashboardNavItem = {
+  label: string;
+  href: string;
+  Icon: LucideIcon;
+  active?: boolean;
+};
+
+export type DashboardSummaryCard = {
+  label: string;
+  value: string;
+  detail: string;
+  trend: string;
+  tone: "blue" | "green" | "amber" | "rose";
+  Icon: LucideIcon;
+};
+
+export type RecentProject = {
+  name: string;
+  code: string;
+  status: string;
+  health: string;
+  focus: string;
+};
+
+export type SprintPlanningItem = {
+  label: string;
+  detail: string;
+  progress: string;
+};
+
+export type KanbanCard = {
+  title: string;
+  meta: string;
+  tag: string;
+};
+
+export type KanbanColumn = {
+  title: string;
+  count: string;
+  accentClass: string;
+  cards: KanbanCard[];
+};
+
+export type RiskItem = {
+  label: string;
+  severity: string;
+  owner: string;
+};
+
+export type AnalyticsHighlight = {
+  label: string;
+  value: string;
+  detail: string;
+};
+
+export type AssistantPrompt = {
+  label: string;
+  detail: string;
+};
+
+export const dashboardNavItems: DashboardNavItem[] = [
+  {
+    label: "Dashboard",
+    href: "/dashboard",
+    Icon: LayoutDashboard,
+    active: true,
+  },
+  {
+    label: "Recent projects",
+    href: "#recent-projects",
+    Icon: FolderKanban,
+  },
+  {
+    label: "Sprint planning",
+    href: "#sprint-planning",
+    Icon: ClipboardList,
+  },
+  {
+    label: "Kanban preview",
+    href: "#kanban-preview",
+    Icon: ListChecks,
+  },
+  {
+    label: "Risk register",
+    href: "#risk-register",
+    Icon: ShieldAlert,
+  },
+  {
+    label: "Analytics",
+    href: "#delivery-analytics",
+    Icon: BarChart3,
+  },
+  {
+    label: "AI assistant",
+    href: "#ai-assistant",
+    Icon: Bot,
+  },
+];
+
+export const dashboardSummaryCards: DashboardSummaryCard[] = [
+  {
+    label: "Projects",
+    value: "4",
+    detail: "Product workspaces staged for CRUD integration.",
+    trend: "+2 ready for schema wiring",
+    tone: "blue",
+    Icon: FolderKanban,
+  },
+  {
+    label: "Active sprints",
+    value: "2",
+    detail: "Static sprint cycles visible in the planning shell.",
+    trend: "1 sprint closing soon",
+    tone: "green",
+    Icon: TimerReset,
+  },
+  {
+    label: "User stories",
+    value: "28",
+    detail: "Placeholder backlog volume for the future board.",
+    trend: "9 shaped for next sprint",
+    tone: "amber",
+    Icon: MessageSquareText,
+  },
+  {
+    label: "Open risks",
+    value: "5",
+    detail: "Mock delivery risks waiting for real project data.",
+    trend: "2 need owner review",
+    tone: "rose",
+    Icon: ShieldAlert,
+  },
+];
+
+export const recentProjects: RecentProject[] = [
+  {
+    name: "Atlas onboarding",
+    code: "ATL",
+    status: "Discovery",
+    health: "On track",
+    focus: "Clarify first-run activation and team invite flow.",
+  },
+  {
+    name: "Northstar sprint rituals",
+    code: "NST",
+    status: "In sprint",
+    health: "Watch",
+    focus: "Keep ceremony notes and blockers visible in one view.",
+  },
+  {
+    name: "Orbit analytics",
+    code: "ORB",
+    status: "Planning",
+    health: "Healthy",
+    focus: "Define dashboard events before instrumentation begins.",
+  },
+];
+
+export const sprintPlanningItems: SprintPlanningItem[] = [
+  {
+    label: "Scope refinement",
+    detail: "Convert top backlog themes into testable stories.",
+    progress: "70%",
+  },
+  {
+    label: "Capacity check",
+    detail: "Balance committed work against team availability.",
+    progress: "45%",
+  },
+  {
+    label: "Review readiness",
+    detail: "Collect acceptance notes for demo candidates.",
+    progress: "30%",
+  },
+];
+
+export const kanbanColumns: KanbanColumn[] = [
+  {
+    title: "Backlog",
+    count: "8",
+    accentClass: "bg-slate-200 text-slate-700",
+    cards: [
+      {
+        title: "Define project empty state",
+        meta: "UX copy - product",
+        tag: "Ready",
+      },
+      {
+        title: "Map profile defaults",
+        meta: "Auth handoff - backend",
+        tag: "Needs review",
+      },
+    ],
+  },
+  {
+    title: "To Do",
+    count: "5",
+    accentClass: "bg-blue-100 text-blue-800",
+    cards: [
+      {
+        title: "Create sprint planning route",
+        meta: "App shell - frontend",
+        tag: "Next",
+      },
+      {
+        title: "Draft risk severity labels",
+        meta: "Domain model - product",
+        tag: "Queued",
+      },
+    ],
+  },
+  {
+    title: "In Progress",
+    count: "3",
+    accentClass: "bg-cyan-100 text-cyan-900",
+    cards: [
+      {
+        title: "Dashboard layout foundation",
+        meta: "Issue #8 - frontend",
+        tag: "Active",
+      },
+      {
+        title: "Auth smoke test notes",
+        meta: "Supabase - QA",
+        tag: "Blocked",
+      },
+    ],
+  },
+  {
+    title: "Review",
+    count: "2",
+    accentClass: "bg-amber-100 text-amber-900",
+    cards: [
+      {
+        title: "README auth setup",
+        meta: "Docs - reviewer",
+        tag: "PR",
+      },
+      {
+        title: "Dashboard copy pass",
+        meta: "Design - product",
+        tag: "QA",
+      },
+    ],
+  },
+  {
+    title: "Done",
+    count: "6",
+    accentClass: "bg-emerald-100 text-emerald-900",
+    cards: [
+      {
+        title: "Supabase SSR clients",
+        meta: "Auth - platform",
+        tag: "Shipped",
+      },
+      {
+        title: "Protected dashboard route",
+        meta: "Security - app",
+        tag: "Shipped",
+      },
+    ],
+  },
+];
+
+export const riskRegisterItems: RiskItem[] = [
+  {
+    label: "Email confirmation setting may differ across environments.",
+    severity: "Medium",
+    owner: "Auth",
+  },
+  {
+    label: "Kanban ordering depends on later drag-and-drop persistence.",
+    severity: "High",
+    owner: "Board",
+  },
+  {
+    label: "AI assistant requires provider limits and audit logging.",
+    severity: "Medium",
+    owner: "AI",
+  },
+];
+
+export const analyticsHighlights: AnalyticsHighlight[] = [
+  {
+    label: "Cycle time",
+    value: "3.8d",
+    detail: "Static benchmark until activity events are connected.",
+  },
+  {
+    label: "Sprint confidence",
+    value: "82%",
+    detail: "Placeholder signal for future delivery forecasting.",
+  },
+  {
+    label: "Review load",
+    value: "7",
+    detail: "Mock stories awaiting acceptance feedback.",
+  },
+];
+
+export const assistantPrompts: AssistantPrompt[] = [
+  {
+    label: "Summarize sprint health",
+    detail: "Future AI prompt for risks, blockers, and scope movement.",
+  },
+  {
+    label: "Draft standup notes",
+    detail: "Future assistant action for async team updates.",
+  },
+  {
+    label: "Find delivery risks",
+    detail: "Future prompt combining board activity and risk history.",
+  },
+];
+
+export const dashboardFocusItems = [
+  {
+    label: "Authenticated shell",
+    detail: "Server-side Supabase user check remains the route gate.",
+    Icon: CircleDot,
+  },
+  {
+    label: "Static operating model",
+    detail: "Metrics and cards are placeholders until project CRUD lands.",
+    Icon: Gauge,
+  },
+  {
+    label: "AI-ready surface",
+    detail: "Assistant space is designed, but no provider calls are made.",
+    Icon: Sparkles,
+  },
+];


### PR DESCRIPTION
## Summary

This PR adds the authenticated dashboard layout for Minavolve.

## Changes

- Added reusable app sidebar
- Added reusable top bar
- Added dashboard summary card component
- Added reusable dashboard section component
- Added Kanban preview component
- Updated `/dashboard` with a polished authenticated app shell
- Displayed authenticated user email in the dashboard
- Preserved logout functionality
- Added static dashboard placeholders for projects, sprints, Kanban, risks, analytics, and AI assistant
- Updated README current status

## Testing

- Ran `npm run lint`
- Ran `npm run dev`
- Logged in with a test user
- Verified `/dashboard` loads when authenticated
- Verified user email appears in the dashboard
- Verified logout works
- Verified logged-out users are redirected from `/dashboard` to `/login`
- Verified `/`, `/login`, and `/register` still load

Closes Issue #8 