### PR TITLE
feat(projects): add project creation and listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Minavolve
 
-Minavolve is an Agile sprint board product concept with room for an AI assistant. This repository currently ships a polished landing page, Supabase email/password authentication, and an authenticated dashboard layout that later issues can connect to project data, drag-and-drop interactions, and AI workflows.
+Minavolve is an Agile sprint board product concept with room for an AI assistant. This repository currently ships a polished landing page, Supabase email/password authentication, an authenticated dashboard layout, and initial Supabase-backed project creation/listing that later issues can extend with sprints, stories, drag-and-drop interactions, and AI workflows.
 
 ## What this issue includes
 
@@ -10,12 +10,14 @@ Minavolve is an Agile sprint board product concept with room for an AI assistant
 - Reusable marketing components for the landing page
 - Supabase email/password login, registration, logout, and protected dashboard access
 - Authenticated dashboard layout with sidebar navigation, top bar, static summary metrics, placeholder work sections, and a five-column Kanban preview
+- Authenticated project listing, project creation, and a basic project workspace placeholder backed by Supabase RLS
 - Starter environment variable documentation in `.env.example`
 - Initial Supabase schema migration for projects, sprints, stories, risks, AI generations, activity, memberships, and profiles
 
 ## What is intentionally not implemented yet
 
-- No project CRUD or sprint CRUD
+- No project editing or deletion
+- No sprint CRUD
 - No drag-and-drop board behavior
 - No AI API routes or provider integration
 
@@ -59,6 +61,8 @@ Minavolve is an Agile sprint board product concept with room for an AI assistant
    - `http://localhost:3000/login`
    - `http://localhost:3000/register`
    - `http://localhost:3000/dashboard`
+   - `http://localhost:3000/projects`
+   - `http://localhost:3000/projects/new`
 
 ## Linting
 
@@ -74,6 +78,9 @@ npm run lint
 - `/login`: Supabase email/password sign-in screen
 - `/register`: Supabase email/password account creation screen
 - `/dashboard`: protected authenticated dashboard shell with static layout data
+- `/projects`: protected Supabase-backed project list
+- `/projects/new`: protected project creation form
+- `/projects/[projectId]`: protected project workspace placeholder
 
 ## Dashboard status
 
@@ -81,11 +88,25 @@ Issue #8 adds the authenticated dashboard shell. The page keeps the existing ser
 
 Current dashboard content is intentionally static:
 
-- Summary cards for projects, active sprints, user stories, and open risks
+- Summary cards for projects, active sprints, user stories, and open risks. The project count is read from Supabase when available.
 - Placeholder sections for recent projects, sprint planning, Kanban preview, risk register, delivery analytics, and AI assistant
 - A visual Kanban preview with Backlog, To Do, In Progress, Review, and Done columns
 
-Real project queries, sprint CRUD, story management, drag-and-drop, charts, and AI provider calls remain out of scope for this issue.
+Sprint CRUD, story management, drag-and-drop, charts, and AI provider calls remain out of scope for this issue.
+
+## Project setup status
+
+Issue #10 adds initial project CRUD foundation:
+
+- `/projects` reads projects through Supabase RLS, so authenticated users only see projects where they are a member or owner.
+- `/projects/new` validates project input with Zod and creates rows in `public.projects`.
+- Project creation sets `owner_id` to the authenticated Supabase user id.
+- The database trigger is expected to add the creator to `public.project_members` as `owner`.
+- Successful project creation redirects to `/projects/[projectId]`.
+
+Project form fields are `name`, `project_key`, `description`, `status`, `start_date`, and `target_end_date`. The current implementation assumes the Supabase cloud schema includes these Issue #10 columns.
+
+If project creation returns a missing `project_key`, `start_date`, or `target_end_date` message, update the Supabase cloud `public.projects` table before retesting project creation.
 
 ## Environment variables
 

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+import Link from "next/link";
+import { Plus } from "lucide-react";
 import { redirect } from "next/navigation";
 
 import { logout } from "@/app/(app)/dashboard/actions";
@@ -7,10 +9,11 @@ import { AppTopbar } from "@/components/app/app-topbar";
 import { DashboardCard } from "@/components/app/dashboard-card";
 import { DashboardSection } from "@/components/app/dashboard-section";
 import { KanbanPreview } from "@/components/app/kanban-preview";
+import { Button } from "@/components/ui/button";
 import {
   analyticsHighlights,
   assistantPrompts,
-  dashboardSummaryCards,
+  getDashboardSummaryCards,
   recentProjects,
   riskRegisterItems,
   sprintPlanningItems,
@@ -33,6 +36,10 @@ export default async function DashboardPage() {
   }
 
   const userEmail = user.email ?? "Authenticated user";
+  const { count: projectCount } = await supabase
+    .from("projects")
+    .select("id", { count: "exact", head: true });
+  const summaryCards = getDashboardSummaryCards(projectCount ?? 0);
 
   return (
     <main className="min-h-screen px-4 py-6 sm:px-6 lg:px-8">
@@ -48,7 +55,7 @@ export default async function DashboardPage() {
             className="grid gap-4 md:grid-cols-2 xl:grid-cols-4"
             aria-label="Dashboard summary"
           >
-            {dashboardSummaryCards.map((card) => (
+            {summaryCards.map((card) => (
               <DashboardCard
                 key={card.label}
                 label={card.label}
@@ -67,11 +74,18 @@ export default async function DashboardPage() {
                 id="recent-projects"
                 eyebrow="Portfolio"
                 title="Recent projects"
-                description="Static project rows provide the dashboard shape before Supabase project queries are connected."
+                description="Project CRUD is now available. This dashboard section still keeps a lightweight planning preview until richer project activity lands."
                 action={
-                  <span className="rounded-full bg-brand-soft px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-brand">
-                    Placeholder data
-                  </span>
+                  <Button
+                    asChild
+                    size="lg"
+                    className="h-10 rounded-2xl bg-slate-950 px-4 text-white hover:bg-slate-800"
+                  >
+                    <Link href="/projects/new">
+                      <Plus className="size-4" />
+                      New project
+                    </Link>
+                  </Button>
                 }
               >
                 <div className="grid gap-3">

--- a/src/app/(app)/projects/[projectId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/page.tsx
@@ -1,0 +1,200 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  ArrowLeft,
+  CalendarDays,
+  ClipboardList,
+  FolderKanban,
+  Plus,
+  ShieldAlert,
+} from "lucide-react";
+import { notFound, redirect } from "next/navigation";
+
+import { AppSidebar } from "@/components/app/app-sidebar";
+import { Button } from "@/components/ui/button";
+import { createClient } from "@/utils/supabase/server";
+
+export const metadata: Metadata = {
+  title: "Project workspace",
+  description: "Minavolve project workspace placeholder.",
+};
+
+type ProjectWorkspacePageProps = {
+  params: Promise<{
+    projectId: string;
+  }>;
+};
+
+type ProjectWorkspace = {
+  id: string;
+  name: string;
+  project_key: string;
+  description: string | null;
+  status: string;
+  start_date: string | null;
+  target_end_date: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+function formatDate(date: string | null) {
+  if (!date) {
+    return "Not set";
+  }
+
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(`${date}T00:00:00`));
+}
+
+export default async function ProjectWorkspacePage({
+  params,
+}: ProjectWorkspacePageProps) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { projectId } = await params;
+  const { data: project, error } = await supabase
+    .from("projects")
+    .select(
+      "id,name,project_key,description,status,start_date,target_end_date,created_at,updated_at",
+    )
+    .eq("id", projectId)
+    .maybeSingle();
+
+  if (error || !project) {
+    notFound();
+  }
+
+  const typedProject = project as ProjectWorkspace;
+
+  return (
+    <main className="min-h-screen px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto flex w-full max-w-[1540px] flex-col gap-6 lg:flex-row">
+        <div className="lg:w-72 lg:shrink-0">
+          <AppSidebar activeHref="/projects" />
+        </div>
+
+        <div className="min-w-0 flex-1 space-y-6">
+          <Link
+            href="/projects"
+            className="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition-colors hover:text-slate-950"
+          >
+            <ArrowLeft className="size-4" />
+            Back to projects
+          </Link>
+
+          <header className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6">
+            <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
+              <div className="flex items-start gap-4">
+                <div className="inline-flex size-14 items-center justify-center rounded-3xl bg-slate-950 font-heading text-sm font-semibold tracking-[0.14em] text-white">
+                  {typedProject.project_key}
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-brand">
+                    Project workspace
+                  </p>
+                  <h1 className="mt-2 font-heading text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                    {typedProject.name}
+                  </h1>
+                  <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
+                    {typedProject.description ??
+                      "No project description yet. Project editing, sprint setup, and board data will be implemented in later issues."}
+                  </p>
+                </div>
+              </div>
+
+              <span className="h-fit rounded-full bg-brand-soft px-4 py-2 text-sm font-semibold capitalize text-brand">
+                {typedProject.status}
+              </span>
+            </div>
+          </header>
+
+          <section className="grid gap-5 md:grid-cols-3">
+            {[
+              {
+                label: "Start date",
+                value: formatDate(typedProject.start_date),
+                Icon: CalendarDays,
+              },
+              {
+                label: "Target end",
+                value: formatDate(typedProject.target_end_date),
+                Icon: CalendarDays,
+              },
+              {
+                label: "Workspace status",
+                value: "Placeholder",
+                Icon: FolderKanban,
+              },
+            ].map((item) => (
+              <article
+                key={item.label}
+                className="rounded-[1.75rem] border border-white/80 bg-white/88 p-5 shadow-[0_24px_70px_-55px_rgba(15,23,42,0.72)]"
+              >
+                <div className="inline-flex size-10 items-center justify-center rounded-2xl bg-brand-soft text-brand">
+                  <item.Icon className="size-5" />
+                </div>
+                <p className="mt-4 text-sm font-medium text-slate-500">
+                  {item.label}
+                </p>
+                <p className="mt-2 font-heading text-2xl font-semibold text-slate-950">
+                  {item.value}
+                </p>
+              </article>
+            ))}
+          </section>
+
+          <section className="grid gap-6 xl:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
+            <article className="rounded-[2rem] border border-dashed border-slate-300 bg-white/72 p-6 shadow-[0_25px_80px_-60px_rgba(15,23,42,0.7)]">
+              <div className="inline-flex size-12 items-center justify-center rounded-2xl bg-slate-950 text-white">
+                <ClipboardList className="size-6" />
+              </div>
+              <h2 className="mt-5 font-heading text-2xl font-semibold text-slate-950">
+                Sprint workspace coming next
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-slate-600">
+                This page confirms project routing and membership-protected
+                access. Sprint CRUD, user stories, Kanban data, risks, charts,
+                and AI workflows remain intentionally out of scope.
+              </p>
+              <Button
+                disabled
+                size="lg"
+                className="mt-6 h-11 rounded-2xl bg-slate-300 px-5 text-slate-600"
+              >
+                <Plus className="size-4" />
+                Add sprint later
+              </Button>
+            </article>
+
+            <article className="rounded-[2rem] border border-white/10 bg-slate-950 p-6 text-white shadow-[0_25px_80px_-55px_rgba(15,23,42,0.9)]">
+              <div className="inline-flex size-12 items-center justify-center rounded-2xl bg-white/10 text-cyan-200">
+                <ShieldAlert className="size-6" />
+              </div>
+              <h2 className="mt-5 font-heading text-2xl font-semibold">
+                Access model
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-slate-300">
+                Project data is read through Supabase RLS. If you can view this
+                workspace, the current user is allowed to read this project.
+              </p>
+              <div className="mt-5 rounded-2xl border border-white/10 bg-white/[0.06] p-4 text-sm text-slate-300">
+                Project members are expected to be created by the database
+                trigger when a project is inserted.
+              </div>
+            </article>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(app)/projects/actions.ts
+++ b/src/app/(app)/projects/actions.ts
@@ -1,0 +1,103 @@
+"use server";
+
+import { randomUUID } from "node:crypto";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { projectFormSchema } from "@/lib/validators/project";
+import { createClient } from "@/utils/supabase/server";
+
+function getString(formData: FormData, key: string) {
+  const value = formData.get(key);
+  return typeof value === "string" ? value : "";
+}
+
+function redirectWithCreateError(message: string): never {
+  redirect(`/projects/new?error=${encodeURIComponent(message)}`);
+}
+
+function getProjectCreateErrorMessage(message: string) {
+  const normalized = message.toLowerCase();
+
+  if (
+    normalized.includes("project_key") &&
+    (normalized.includes("schema cache") || normalized.includes("column"))
+  ) {
+    return "The projects table is missing the Issue #10 project_key column. Apply the latest Supabase schema before creating projects.";
+  }
+
+  if (
+    normalized.includes("start_date") ||
+    normalized.includes("target_end_date")
+  ) {
+    return "The projects table is missing the Issue #10 date columns. Apply the latest Supabase schema before creating projects.";
+  }
+
+  if (
+    normalized.includes("projects_status_check") ||
+    normalized.includes("violates check constraint")
+  ) {
+    return "The selected status is not supported by the current projects table schema.";
+  }
+
+  if (normalized.includes("duplicate") || normalized.includes("unique")) {
+    return "A project with that name or key already exists for your account.";
+  }
+
+  if (normalized.includes("row-level security")) {
+    return "Supabase blocked project creation. Confirm you are signed in and the project RLS policies are applied.";
+  }
+
+  if (normalized.includes("foreign key")) {
+    return "Your profile is not ready yet. Sign out, sign back in, and try again.";
+  }
+
+  return "Unable to create project. Check the form and try again.";
+}
+
+export async function createProject(formData: FormData) {
+  const parsed = projectFormSchema.safeParse({
+    name: getString(formData, "name"),
+    project_key: getString(formData, "project_key"),
+    description: getString(formData, "description"),
+    status: getString(formData, "status"),
+    start_date: getString(formData, "start_date"),
+    target_end_date: getString(formData, "target_end_date"),
+  });
+
+  if (!parsed.success) {
+    redirectWithCreateError(
+      parsed.error.issues[0]?.message ?? "Enter valid project details.",
+    );
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const projectId = randomUUID();
+  const { error } = await supabase.from("projects").insert({
+    id: projectId,
+    owner_id: user.id,
+    name: parsed.data.name,
+    project_key: parsed.data.project_key,
+    description: parsed.data.description,
+    status: parsed.data.status,
+    start_date: parsed.data.start_date,
+    target_end_date: parsed.data.target_end_date,
+  });
+
+  if (error) {
+    redirectWithCreateError(getProjectCreateErrorMessage(error.message));
+  }
+
+  revalidatePath("/dashboard");
+  revalidatePath("/projects");
+  redirect(`/projects/${projectId}`);
+}

--- a/src/app/(app)/projects/new/page.tsx
+++ b/src/app/(app)/projects/new/page.tsx
@@ -1,0 +1,81 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft, FolderPlus } from "lucide-react";
+import { redirect } from "next/navigation";
+
+import { AppSidebar } from "@/components/app/app-sidebar";
+import { ProjectForm } from "@/components/projects/project-form";
+import { createClient } from "@/utils/supabase/server";
+
+export const metadata: Metadata = {
+  title: "New project",
+  description: "Create a Minavolve project.",
+};
+
+type NewProjectPageProps = {
+  searchParams: Promise<{
+    error?: string | string[];
+  }>;
+};
+
+function getSearchParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export default async function NewProjectPage({
+  searchParams,
+}: NewProjectPageProps) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const params = await searchParams;
+  const error = getSearchParam(params.error);
+
+  return (
+    <main className="min-h-screen px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto flex w-full max-w-[1540px] flex-col gap-6 lg:flex-row">
+        <div className="lg:w-72 lg:shrink-0">
+          <AppSidebar activeHref="/projects" />
+        </div>
+
+        <div className="min-w-0 flex-1 space-y-6">
+          <Link
+            href="/projects"
+            className="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition-colors hover:text-slate-950"
+          >
+            <ArrowLeft className="size-4" />
+            Back to projects
+          </Link>
+
+          <header className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6">
+            <div className="flex items-start gap-4">
+              <div className="inline-flex size-12 items-center justify-center rounded-2xl bg-slate-950 text-white">
+                <FolderPlus className="size-6" />
+              </div>
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-brand">
+                  Create workspace
+                </p>
+                <h1 className="mt-2 font-heading text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                  New project
+                </h1>
+                <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+                  Create the project record in Supabase. The database trigger
+                  should add you to project_members as the owner.
+                </p>
+              </div>
+            </div>
+          </header>
+
+          <ProjectForm error={error} />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(app)/projects/page.tsx
+++ b/src/app/(app)/projects/page.tsx
@@ -1,0 +1,140 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { FolderKanban, Plus } from "lucide-react";
+import { redirect } from "next/navigation";
+
+import { AppSidebar } from "@/components/app/app-sidebar";
+import { Button } from "@/components/ui/button";
+import {
+  ProjectCard,
+  type ProjectCardProject,
+} from "@/components/projects/project-card";
+import { createClient } from "@/utils/supabase/server";
+
+export const metadata: Metadata = {
+  title: "Projects",
+  description: "Authenticated Minavolve project listing.",
+};
+
+function getProjectListError(message: string) {
+  const normalized = message.toLowerCase();
+
+  if (
+    normalized.includes("project_key") ||
+    normalized.includes("start_date") ||
+    normalized.includes("target_end_date")
+  ) {
+    return "The projects table is missing Issue #10 columns. Apply the latest Supabase schema before project listing can use the new fields.";
+  }
+
+  return "Unable to load projects right now.";
+}
+
+export default async function ProjectsPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { data, error } = await supabase
+    .from("projects")
+    .select(
+      "id,name,project_key,description,status,start_date,target_end_date,created_at",
+    )
+    .order("created_at", { ascending: false });
+
+  const projects = (data ?? []) as ProjectCardProject[];
+
+  return (
+    <main className="min-h-screen px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto flex w-full max-w-[1540px] flex-col gap-6 lg:flex-row">
+        <div className="lg:w-72 lg:shrink-0">
+          <AppSidebar activeHref="/projects" />
+        </div>
+
+        <div className="min-w-0 flex-1 space-y-6">
+          <header className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6">
+            <div className="flex flex-col gap-5 md:flex-row md:items-center md:justify-between">
+              <div className="flex items-start gap-4">
+                <div className="inline-flex size-12 items-center justify-center rounded-2xl bg-slate-950 text-white">
+                  <FolderKanban className="size-6" />
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-brand">
+                    Project portfolio
+                  </p>
+                  <h1 className="mt-2 font-heading text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                    Projects
+                  </h1>
+                  <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+                    Projects are loaded through Supabase RLS, so this list only
+                    includes workspaces where you are a member or owner.
+                  </p>
+                </div>
+              </div>
+
+              <Button
+                asChild
+                size="lg"
+                className="h-11 rounded-2xl bg-slate-950 px-5 text-white hover:bg-slate-800"
+              >
+                <Link href="/projects/new">
+                  <Plus className="size-4" />
+                  New project
+                </Link>
+              </Button>
+            </div>
+          </header>
+
+          {error ? (
+            <section className="rounded-[2rem] border border-rose-200 bg-rose-50 p-5 text-rose-900 sm:p-6">
+              <h2 className="font-heading text-2xl font-semibold">
+                Projects could not load
+              </h2>
+              <p className="mt-2 text-sm leading-6">
+                {getProjectListError(error.message)}
+              </p>
+            </section>
+          ) : projects.length > 0 ? (
+            <section
+              className="grid gap-5 md:grid-cols-2 xl:grid-cols-3"
+              aria-label="Project list"
+            >
+              {projects.map((project) => (
+                <ProjectCard key={project.id} project={project} />
+              ))}
+            </section>
+          ) : (
+            <section className="rounded-[2rem] border border-dashed border-slate-300 bg-white/72 p-8 text-center shadow-[0_25px_80px_-60px_rgba(15,23,42,0.7)]">
+              <div className="mx-auto inline-flex size-14 items-center justify-center rounded-3xl bg-brand-soft text-brand">
+                <FolderKanban className="size-7" />
+              </div>
+              <h2 className="mt-5 font-heading text-2xl font-semibold text-slate-950">
+                No projects yet
+              </h2>
+              <p className="mx-auto mt-2 max-w-xl text-sm leading-6 text-slate-600">
+                Create your first project to seed the authenticated workspace.
+                Sprint planning, stories, risks, and AI support will attach to
+                projects in later issues.
+              </p>
+              <Button
+                asChild
+                size="lg"
+                className="mt-6 h-11 rounded-2xl bg-slate-950 px-5 text-white hover:bg-slate-800"
+              >
+                <Link href="/projects/new">
+                  <Plus className="size-4" />
+                  Create first project
+                </Link>
+              </Button>
+            </section>
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/app/app-sidebar.tsx
+++ b/src/components/app/app-sidebar.tsx
@@ -5,7 +5,11 @@ import { dashboardFocusItems, dashboardNavItems } from "@/lib/dashboard";
 import { siteConfig } from "@/lib/site";
 import { cn } from "@/lib/utils";
 
-export function AppSidebar() {
+type AppSidebarProps = {
+  activeHref?: string;
+};
+
+export function AppSidebar({ activeHref = "/dashboard" }: AppSidebarProps) {
   return (
     <aside className="lg:sticky lg:top-6 lg:h-[calc(100vh-3rem)]">
       <div className="flex h-full flex-col rounded-[2rem] border border-white/80 bg-slate-950 p-4 text-slate-50 shadow-[0_32px_90px_-55px_rgba(15,23,42,0.95)] sm:p-5">
@@ -22,32 +26,38 @@ export function AppSidebar() {
         </Link>
 
         <nav className="mt-7 space-y-1" aria-label="Dashboard navigation">
-          {dashboardNavItems.map((item) => (
-            <Link
-              key={item.label}
-              href={item.href}
-              aria-current={item.active ? "page" : undefined}
-              className={cn(
-                "group flex items-center justify-between rounded-2xl px-3 py-3 text-sm font-medium transition-colors",
-                item.active
-                  ? "bg-white text-slate-950"
-                  : "text-slate-300 hover:bg-white/10 hover:text-white",
-              )}
-            >
-              <span className="flex items-center gap-3">
-                <item.Icon className="size-4" />
-                {item.label}
-              </span>
-              {item.active ? (
-                <ChevronRight className="size-4 text-brand" />
-              ) : null}
-            </Link>
-          ))}
+          {dashboardNavItems.map((item) => {
+            const isActive =
+              item.href === activeHref ||
+              (item.href === "/projects" && activeHref.startsWith("/projects"));
+
+            return (
+              <Link
+                key={item.label}
+                href={item.href}
+                aria-current={isActive ? "page" : undefined}
+                className={cn(
+                  "group flex items-center justify-between rounded-2xl px-3 py-3 text-sm font-medium transition-colors",
+                  isActive
+                    ? "bg-white text-slate-950"
+                    : "text-slate-300 hover:bg-white/10 hover:text-white",
+                )}
+              >
+                <span className="flex items-center gap-3">
+                  <item.Icon className="size-4" />
+                  {item.label}
+                </span>
+                {isActive ? (
+                  <ChevronRight className="size-4 text-brand" />
+                ) : null}
+              </Link>
+            );
+          })}
         </nav>
 
         <div className="mt-7 rounded-[1.5rem] border border-white/10 bg-white/[0.06] p-4">
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-200">
-            Issue #8 scope
+            Current scope
           </p>
           <div className="mt-4 space-y-4">
             {dashboardFocusItems.map((item) => (

--- a/src/components/projects/project-card.tsx
+++ b/src/components/projects/project-card.tsx
@@ -1,0 +1,81 @@
+import Link from "next/link";
+import { ArrowUpRight, CalendarDays } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export type ProjectCardProject = {
+  id: string;
+  name: string;
+  project_key: string;
+  description: string | null;
+  status: string;
+  start_date: string | null;
+  target_end_date: string | null;
+  created_at: string;
+};
+
+const statusClasses: Record<string, string> = {
+  active: "bg-emerald-100 text-emerald-800",
+  paused: "bg-amber-100 text-amber-900",
+  completed: "bg-blue-100 text-blue-800",
+  archived: "bg-slate-200 text-slate-700",
+};
+
+function formatDate(date: string | null) {
+  if (!date) {
+    return "Not set";
+  }
+
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(`${date}T00:00:00`));
+}
+
+export function ProjectCard({ project }: { project: ProjectCardProject }) {
+  return (
+    <Link
+      href={`/projects/${project.id}`}
+      className="group block rounded-[1.75rem] border border-white/80 bg-white/88 p-5 shadow-[0_24px_70px_-55px_rgba(15,23,42,0.72)] transition-transform duration-300 hover:-translate-y-1 hover:border-brand/30"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="inline-flex size-12 shrink-0 items-center justify-center rounded-2xl bg-slate-950 font-heading text-sm font-semibold tracking-[0.14em] text-white">
+            {project.project_key}
+          </div>
+          <div className="min-w-0">
+            <h2 className="truncate font-heading text-xl font-semibold text-slate-950">
+              {project.name}
+            </h2>
+            <p className="mt-1 text-sm text-slate-500">
+              Created {formatDate(project.created_at.slice(0, 10))}
+            </p>
+          </div>
+        </div>
+
+        <ArrowUpRight className="size-5 shrink-0 text-slate-400 transition-colors group-hover:text-brand" />
+      </div>
+
+      <p className="mt-5 line-clamp-3 min-h-[4.5rem] text-sm leading-6 text-slate-600">
+        {project.description ??
+          "No description yet. Add sprint goals and project context in later issues."}
+      </p>
+
+      <div className="mt-5 flex flex-wrap items-center gap-2">
+        <span
+          className={cn(
+            "rounded-full px-3 py-1.5 text-xs font-semibold capitalize",
+            statusClasses[project.status] ?? "bg-slate-100 text-slate-700",
+          )}
+        >
+          {project.status}
+        </span>
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-3 py-1.5 text-xs font-medium text-slate-600">
+          <CalendarDays className="size-3.5" />
+          {formatDate(project.start_date)} - {formatDate(project.target_end_date)}
+        </span>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/projects/project-form.tsx
+++ b/src/components/projects/project-form.tsx
@@ -1,0 +1,120 @@
+import { createProject } from "@/app/(app)/projects/actions";
+import { Button } from "@/components/ui/button";
+import { projectStatuses } from "@/lib/validators/project";
+
+const statusLabels: Record<(typeof projectStatuses)[number], string> = {
+  active: "Active",
+  paused: "Paused",
+  completed: "Completed",
+  archived: "Archived",
+};
+
+type ProjectFormProps = {
+  error?: string;
+};
+
+export function ProjectForm({ error }: ProjectFormProps) {
+  return (
+    <form
+      action={createProject}
+      className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6"
+    >
+      {error ? (
+        <div className="mb-6 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm leading-6 text-rose-800">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="grid gap-5">
+        <label className="block text-sm font-semibold text-slate-800">
+          Project name
+          <input
+            name="name"
+            required
+            minLength={3}
+            maxLength={120}
+            placeholder="Minavolve launch"
+            className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+          />
+        </label>
+
+        <div className="grid gap-5 md:grid-cols-2">
+          <label className="block text-sm font-semibold text-slate-800">
+            Project key
+            <input
+              name="project_key"
+              required
+              minLength={2}
+              maxLength={10}
+              pattern="[A-Za-z0-9]{2,10}"
+              placeholder="MINA"
+              className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 font-mono text-sm uppercase tracking-[0.12em] text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+            />
+            <span className="mt-2 block text-xs font-normal leading-5 text-slate-500">
+              2-10 letters or numbers. The server stores it uppercase.
+            </span>
+          </label>
+
+          <label className="block text-sm font-semibold text-slate-800">
+            Status
+            <select
+              name="status"
+              defaultValue="active"
+              className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+            >
+              {projectStatuses.map((status) => (
+                <option key={status} value={status}>
+                  {statusLabels[status]}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <label className="block text-sm font-semibold text-slate-800">
+          Description
+          <textarea
+            name="description"
+            rows={5}
+            maxLength={2000}
+            placeholder="What is this project trying to deliver?"
+            className="mt-2 w-full resize-y rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm leading-6 text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+          />
+        </label>
+
+        <div className="grid gap-5 md:grid-cols-2">
+          <label className="block text-sm font-semibold text-slate-800">
+            Start date
+            <input
+              name="start_date"
+              type="date"
+              className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+            />
+          </label>
+
+          <label className="block text-sm font-semibold text-slate-800">
+            Target end date
+            <input
+              name="target_end_date"
+              type="date"
+              className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+            />
+          </label>
+        </div>
+      </div>
+
+      <div className="mt-7 flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm leading-6 text-slate-500">
+          Sprint, story, risk, and AI data will be connected in later issues.
+        </p>
+        <Button
+          type="submit"
+          size="lg"
+          className="h-11 rounded-2xl bg-slate-950 px-5 text-white hover:bg-slate-800"
+        >
+          Create project
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/lib/dashboard.ts
+++ b/src/lib/dashboard.ts
@@ -18,7 +18,6 @@ export type DashboardNavItem = {
   label: string;
   href: string;
   Icon: LucideIcon;
-  active?: boolean;
 };
 
 export type DashboardSummaryCard = {
@@ -79,36 +78,35 @@ export const dashboardNavItems: DashboardNavItem[] = [
     label: "Dashboard",
     href: "/dashboard",
     Icon: LayoutDashboard,
-    active: true,
   },
   {
-    label: "Recent projects",
-    href: "#recent-projects",
+    label: "Projects",
+    href: "/projects",
     Icon: FolderKanban,
   },
   {
     label: "Sprint planning",
-    href: "#sprint-planning",
+    href: "/dashboard#sprint-planning",
     Icon: ClipboardList,
   },
   {
     label: "Kanban preview",
-    href: "#kanban-preview",
+    href: "/dashboard#kanban-preview",
     Icon: ListChecks,
   },
   {
     label: "Risk register",
-    href: "#risk-register",
+    href: "/dashboard#risk-register",
     Icon: ShieldAlert,
   },
   {
     label: "Analytics",
-    href: "#delivery-analytics",
+    href: "/dashboard#delivery-analytics",
     Icon: BarChart3,
   },
   {
     label: "AI assistant",
-    href: "#ai-assistant",
+    href: "/dashboard#ai-assistant",
     Icon: Bot,
   },
 ];
@@ -116,9 +114,9 @@ export const dashboardNavItems: DashboardNavItem[] = [
 export const dashboardSummaryCards: DashboardSummaryCard[] = [
   {
     label: "Projects",
-    value: "4",
-    detail: "Product workspaces staged for CRUD integration.",
-    trend: "+2 ready for schema wiring",
+    value: "0",
+    detail: "Supabase projects where the current user is a member.",
+    trend: "Create a project to seed the workspace",
     tone: "blue",
     Icon: FolderKanban,
   },
@@ -147,6 +145,23 @@ export const dashboardSummaryCards: DashboardSummaryCard[] = [
     Icon: ShieldAlert,
   },
 ];
+
+export function getDashboardSummaryCards(projectCount: number) {
+  return dashboardSummaryCards.map((card) => {
+    if (card.label !== "Projects") {
+      return card;
+    }
+
+    return {
+      ...card,
+      value: String(projectCount),
+      trend:
+        projectCount === 1
+          ? "1 project available through RLS"
+          : `${projectCount} projects available through RLS`,
+    };
+  });
+}
 
 export const recentProjects: RecentProject[] = [
   {
@@ -336,8 +351,8 @@ export const dashboardFocusItems = [
     Icon: CircleDot,
   },
   {
-    label: "Static operating model",
-    detail: "Metrics and cards are placeholders until project CRUD lands.",
+    label: "Project CRUD foundation",
+    detail: "Projects can be created and listed through Supabase RLS.",
     Icon: Gauge,
   },
   {

--- a/src/lib/validators/project.ts
+++ b/src/lib/validators/project.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+
+export const projectStatuses = [
+  "active",
+  "paused",
+  "completed",
+  "archived",
+] as const;
+
+export type ProjectStatus = (typeof projectStatuses)[number];
+
+const optionalDateSchema = z.preprocess((value) => {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}, z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Use a valid date.").nullable());
+
+export const projectFormSchema = z
+  .object({
+    name: z
+      .string()
+      .trim()
+      .min(3, "Project name must be at least 3 characters.")
+      .max(120, "Project name must be 120 characters or fewer."),
+    project_key: z
+      .string()
+      .trim()
+      .transform((value) => value.toUpperCase())
+      .refine(
+        (value) => value.length >= 2 && value.length <= 10,
+        "Project key must be 2 to 10 characters.",
+      )
+      .refine(
+        (value) => /^[A-Z0-9]+$/.test(value),
+        "Project key can only use uppercase letters and numbers.",
+      ),
+    description: z
+      .string()
+      .trim()
+      .max(2000, "Description must be 2000 characters or fewer.")
+      .transform((value) => (value.length > 0 ? value : null)),
+    status: z.enum(projectStatuses),
+    start_date: optionalDateSchema,
+    target_end_date: optionalDateSchema,
+  })
+  .refine(
+    (project) =>
+      !project.start_date ||
+      !project.target_end_date ||
+      project.target_end_date >= project.start_date,
+    {
+      message: "Target end date cannot be earlier than start date.",
+      path: ["target_end_date"],
+    },
+  );
+
+export type ProjectFormValues = z.infer<typeof projectFormSchema>;


### PR DESCRIPTION
## Summary

This PR implements authenticated project creation and project listing for Minavolve.

## Changes

- Added `/projects` page
- Added `/projects/new` page
- Added `/projects/[projectId]` workspace placeholder
- Added server action for creating projects
- Added project form validation with zod
- Added reusable project form component
- Added reusable project card component
- Connected project creation to Supabase
- Listed authenticated user's projects from Supabase
- Updated dashboard project summary/section
- Updated sidebar navigation with Projects link
- Added project empty states and form error handling
- Updated README current status

## Testing

- Ran `npm run lint`
- Ran `npm run dev`
- Logged in with a test user
- Verified `/projects` loads
- Verified empty state appears when no projects exist
- Created a project through `/projects/new`
- Verified redirect to `/projects/[projectId]`
- Verified project appears on `/projects`
- Verified project row appears in Supabase `projects`
- Verified owner membership row appears in Supabase `project_members`
- Verified invalid project form input shows errors
- Verified logged-out users cannot access project routes
- Verified `/`, `/login`, `/register`, and `/dashboard` still work

Closes Issue #10 