### PR TITLE
feat(sprints): add sprint creation and listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Minavolve
 
-Minavolve is an Agile sprint board product concept with room for an AI assistant. This repository currently ships a polished landing page, Supabase email/password authentication, an authenticated dashboard layout, and initial Supabase-backed project creation/listing that later issues can extend with sprints, stories, drag-and-drop interactions, and AI workflows.
+Minavolve is an Agile sprint board product concept with room for an AI assistant. This repository currently ships a polished landing page, Supabase email/password authentication, an authenticated dashboard layout, and initial Supabase-backed project and sprint creation/listing that later issues can extend with stories, drag-and-drop interactions, and AI workflows.
 
 ## What this issue includes
 
@@ -11,14 +11,17 @@ Minavolve is an Agile sprint board product concept with room for an AI assistant
 - Supabase email/password login, registration, logout, and protected dashboard access
 - Authenticated dashboard layout with sidebar navigation, top bar, static summary metrics, placeholder work sections, and a five-column Kanban preview
 - Authenticated project listing, project creation, and a basic project workspace placeholder backed by Supabase RLS
+- Project-scoped sprint listing, sprint creation, and a basic sprint workspace placeholder backed by Supabase RLS
 - Starter environment variable documentation in `.env.example`
 - Initial Supabase schema migration for projects, sprints, stories, risks, AI generations, activity, memberships, and profiles
 
 ## What is intentionally not implemented yet
 
 - No project editing or deletion
-- No sprint CRUD
+- No sprint editing or deletion
+- No user story CRUD
 - No drag-and-drop board behavior
+- No charts or risk register CRUD
 - No AI API routes or provider integration
 
 ## Tech stack
@@ -63,6 +66,7 @@ Minavolve is an Agile sprint board product concept with room for an AI assistant
    - `http://localhost:3000/dashboard`
    - `http://localhost:3000/projects`
    - `http://localhost:3000/projects/new`
+   - `http://localhost:3000/projects/[projectId]/sprints/new`
 
 ## Linting
 
@@ -80,7 +84,9 @@ npm run lint
 - `/dashboard`: protected authenticated dashboard shell with static layout data
 - `/projects`: protected Supabase-backed project list
 - `/projects/new`: protected project creation form
-- `/projects/[projectId]`: protected project workspace placeholder
+- `/projects/[projectId]`: protected project workspace with project-scoped sprint list
+- `/projects/[projectId]/sprints/new`: protected sprint creation form
+- `/projects/[projectId]/sprints/[sprintId]`: protected sprint workspace placeholder
 
 ## Dashboard status
 
@@ -88,11 +94,11 @@ Issue #8 adds the authenticated dashboard shell. The page keeps the existing ser
 
 Current dashboard content is intentionally static:
 
-- Summary cards for projects, active sprints, user stories, and open risks. The project count is read from Supabase when available.
+- Summary cards for projects, active sprints, user stories, and open risks. Project and active sprint counts are read from Supabase when available.
 - Placeholder sections for recent projects, sprint planning, Kanban preview, risk register, delivery analytics, and AI assistant
 - A visual Kanban preview with Backlog, To Do, In Progress, Review, and Done columns
 
-Sprint CRUD, story management, drag-and-drop, charts, and AI provider calls remain out of scope for this issue.
+Story management, drag-and-drop, charts, risk CRUD, and AI provider calls remain out of scope for this issue.
 
 ## Project setup status
 
@@ -107,6 +113,20 @@ Issue #10 adds initial project CRUD foundation:
 Project form fields are `name`, `project_key`, `description`, `status`, `start_date`, and `target_end_date`. The current implementation assumes the Supabase cloud schema includes these Issue #10 columns.
 
 If project creation returns a missing `project_key`, `start_date`, or `target_end_date` message, update the Supabase cloud `public.projects` table before retesting project creation.
+
+## Sprint setup status
+
+Issue #12 adds initial sprint CRUD foundation:
+
+- Project workspaces read sprints from `public.sprints` where `project_id` matches the current project route.
+- `/projects/[projectId]/sprints/new` validates sprint input with Zod and creates rows in `public.sprints`.
+- Sprint creation sets `project_id` from the route parameter and relies on Supabase RLS to confirm the authenticated user can access that project.
+- Successful sprint creation redirects to `/projects/[projectId]/sprints/[sprintId]`.
+- The dashboard active sprint count is read from Supabase when available.
+
+Sprint form fields are `name`, `goal`, `start_date`, `end_date`, and `status`. The current implementation assumes the Supabase cloud schema includes these Issue #12 columns.
+
+If sprint creation or listing returns a missing `start_date` or `end_date` message, update the Supabase cloud `public.sprints` table before retesting sprint workflows.
 
 ## Environment variables
 

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -39,7 +39,14 @@ export default async function DashboardPage() {
   const { count: projectCount } = await supabase
     .from("projects")
     .select("id", { count: "exact", head: true });
-  const summaryCards = getDashboardSummaryCards(projectCount ?? 0);
+  const { count: activeSprintCount } = await supabase
+    .from("sprints")
+    .select("id", { count: "exact", head: true })
+    .eq("status", "active");
+  const summaryCards = getDashboardSummaryCards(
+    projectCount ?? 0,
+    activeSprintCount ?? 0,
+  );
 
   return (
     <main className="min-h-screen px-4 py-6 sm:px-6 lg:px-8">

--- a/src/app/(app)/projects/[projectId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/page.tsx
@@ -7,10 +7,15 @@ import {
   FolderKanban,
   Plus,
   ShieldAlert,
+  TimerReset,
 } from "lucide-react";
 import { notFound, redirect } from "next/navigation";
 
 import { AppSidebar } from "@/components/app/app-sidebar";
+import {
+  SprintCard,
+  type SprintCardSprint,
+} from "@/components/sprints/sprint-card";
 import { Button } from "@/components/ui/button";
 import { createClient } from "@/utils/supabase/server";
 
@@ -36,6 +41,21 @@ type ProjectWorkspace = {
   created_at: string;
   updated_at: string;
 };
+
+function getSprintListError(message: string) {
+  const normalized = message.toLowerCase();
+
+  if (
+    normalized.includes("start_date") ||
+    normalized.includes("end_date") ||
+    normalized.includes("schema cache") ||
+    normalized.includes("column")
+  ) {
+    return "The sprints table is missing the Issue #12 start_date or end_date columns. Apply the latest Supabase schema before listing sprints.";
+  }
+
+  return "Unable to load sprints for this project right now.";
+}
 
 function formatDate(date: string | null) {
   if (!date) {
@@ -75,6 +95,12 @@ export default async function ProjectWorkspacePage({
   }
 
   const typedProject = project as ProjectWorkspace;
+  const { data: sprints, error: sprintsError } = await supabase
+    .from("sprints")
+    .select("id,project_id,name,goal,status,start_date,end_date,created_at")
+    .eq("project_id", projectId)
+    .order("created_at", { ascending: false });
+  const sprintRows = (sprints ?? []) as SprintCardSprint[];
 
   return (
     <main className="min-h-screen px-4 py-6 sm:px-6 lg:px-8">
@@ -154,27 +180,68 @@ export default async function ProjectWorkspacePage({
           </section>
 
           <section className="grid gap-6 xl:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
-            <article className="rounded-[2rem] border border-dashed border-slate-300 bg-white/72 p-6 shadow-[0_25px_80px_-60px_rgba(15,23,42,0.7)]">
-              <div className="inline-flex size-12 items-center justify-center rounded-2xl bg-slate-950 text-white">
-                <ClipboardList className="size-6" />
+            <section className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-brand">
+                    Sprint planning
+                  </p>
+                  <h2 className="mt-2 font-heading text-2xl font-semibold text-slate-950">
+                    Project sprints
+                  </h2>
+                  <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+                    Sprints are scoped to this project and read through
+                    Supabase RLS.
+                  </p>
+                </div>
+                <Button
+                  asChild
+                  size="lg"
+                  className="h-10 rounded-2xl bg-slate-950 px-4 text-white hover:bg-slate-800"
+                >
+                  <Link href={`/projects/${typedProject.id}/sprints/new`}>
+                    <Plus className="size-4" />
+                    New sprint
+                  </Link>
+                </Button>
               </div>
-              <h2 className="mt-5 font-heading text-2xl font-semibold text-slate-950">
-                Sprint workspace coming next
-              </h2>
-              <p className="mt-2 text-sm leading-6 text-slate-600">
-                This page confirms project routing and membership-protected
-                access. Sprint CRUD, user stories, Kanban data, risks, charts,
-                and AI workflows remain intentionally out of scope.
-              </p>
-              <Button
-                disabled
-                size="lg"
-                className="mt-6 h-11 rounded-2xl bg-slate-300 px-5 text-slate-600"
-              >
-                <Plus className="size-4" />
-                Add sprint later
-              </Button>
-            </article>
+
+              {sprintsError ? (
+                <div className="mt-6 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm leading-6 text-rose-800">
+                  {getSprintListError(sprintsError.message)}
+                </div>
+              ) : sprintRows.length > 0 ? (
+                <div className="mt-6 grid gap-4 md:grid-cols-2">
+                  {sprintRows.map((sprint) => (
+                    <SprintCard key={sprint.id} sprint={sprint} />
+                  ))}
+                </div>
+              ) : (
+                <div className="mt-6 rounded-[1.75rem] border border-dashed border-slate-300 bg-slate-50/80 p-6 text-center">
+                  <div className="mx-auto inline-flex size-12 items-center justify-center rounded-2xl bg-brand-soft text-brand">
+                    <TimerReset className="size-6" />
+                  </div>
+                  <h3 className="mt-4 font-heading text-2xl font-semibold text-slate-950">
+                    No sprints yet
+                  </h3>
+                  <p className="mx-auto mt-2 max-w-xl text-sm leading-6 text-slate-600">
+                    Create the first sprint for this project. User stories,
+                    Kanban data, risks, charts, and AI support will connect to
+                    sprints in later issues.
+                  </p>
+                  <Button
+                    asChild
+                    size="lg"
+                    className="mt-6 h-11 rounded-2xl bg-slate-950 px-5 text-white hover:bg-slate-800"
+                  >
+                    <Link href={`/projects/${typedProject.id}/sprints/new`}>
+                      <ClipboardList className="size-4" />
+                      Create first sprint
+                    </Link>
+                  </Button>
+                </div>
+              )}
+            </section>
 
             <article className="rounded-[2rem] border border-white/10 bg-slate-950 p-6 text-white shadow-[0_25px_80px_-55px_rgba(15,23,42,0.9)]">
               <div className="inline-flex size-12 items-center justify-center rounded-2xl bg-white/10 text-cyan-200">

--- a/src/app/(app)/projects/[projectId]/sprints/[sprintId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/sprints/[sprintId]/page.tsx
@@ -1,0 +1,188 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  ArrowLeft,
+  CalendarDays,
+  ClipboardList,
+  Columns3,
+  Target,
+} from "lucide-react";
+import { notFound, redirect } from "next/navigation";
+
+import { AppSidebar } from "@/components/app/app-sidebar";
+import { createClient } from "@/utils/supabase/server";
+
+export const metadata: Metadata = {
+  title: "Sprint workspace",
+  description: "Minavolve sprint workspace placeholder.",
+};
+
+type SprintDetailPageProps = {
+  params: Promise<{
+    projectId: string;
+    sprintId: string;
+  }>;
+};
+
+type SprintProject = {
+  id: string;
+  name: string;
+  project_key: string;
+};
+
+type SprintDetail = {
+  id: string;
+  project_id: string;
+  name: string;
+  goal: string | null;
+  status: string;
+  start_date: string | null;
+  end_date: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+function formatDate(date: string | null) {
+  if (!date) {
+    return "Not set";
+  }
+
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(`${date}T00:00:00`));
+}
+
+export default async function SprintDetailPage({
+  params,
+}: SprintDetailPageProps) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { projectId, sprintId } = await params;
+  const [{ data: project, error: projectError }, { data: sprint, error }] =
+    await Promise.all([
+      supabase
+        .from("projects")
+        .select("id,name,project_key")
+        .eq("id", projectId)
+        .maybeSingle(),
+      supabase
+        .from("sprints")
+        .select(
+          "id,project_id,name,goal,status,start_date,end_date,created_at,updated_at",
+        )
+        .eq("project_id", projectId)
+        .eq("id", sprintId)
+        .maybeSingle(),
+    ]);
+
+  if (projectError || error || !project || !sprint) {
+    notFound();
+  }
+
+  const typedProject = project as SprintProject;
+  const typedSprint = sprint as SprintDetail;
+
+  return (
+    <main className="min-h-screen px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto flex w-full max-w-[1540px] flex-col gap-6 lg:flex-row">
+        <div className="lg:w-72 lg:shrink-0">
+          <AppSidebar activeHref="/projects" />
+        </div>
+
+        <div className="min-w-0 flex-1 space-y-6">
+          <Link
+            href={`/projects/${typedProject.id}`}
+            className="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition-colors hover:text-slate-950"
+          >
+            <ArrowLeft className="size-4" />
+            Back to {typedProject.name}
+          </Link>
+
+          <header className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6">
+            <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
+              <div className="flex items-start gap-4">
+                <div className="inline-flex size-14 items-center justify-center rounded-3xl bg-slate-950 text-white">
+                  <ClipboardList className="size-7" />
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-brand">
+                    {typedProject.project_key} sprint workspace
+                  </p>
+                  <h1 className="mt-2 font-heading text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                    {typedSprint.name}
+                  </h1>
+                  <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
+                    {typedSprint.goal ??
+                      "No sprint goal yet. User stories, Kanban cards, and delivery metrics will be connected in later issues."}
+                  </p>
+                </div>
+              </div>
+
+              <span className="h-fit rounded-full bg-brand-soft px-4 py-2 text-sm font-semibold capitalize text-brand">
+                {typedSprint.status}
+              </span>
+            </div>
+          </header>
+
+          <section className="grid gap-5 md:grid-cols-3">
+            {[
+              {
+                label: "Start date",
+                value: formatDate(typedSprint.start_date),
+                Icon: CalendarDays,
+              },
+              {
+                label: "End date",
+                value: formatDate(typedSprint.end_date),
+                Icon: CalendarDays,
+              },
+              {
+                label: "Board state",
+                value: "Placeholder",
+                Icon: Columns3,
+              },
+            ].map((item) => (
+              <article
+                key={item.label}
+                className="rounded-[1.75rem] border border-white/80 bg-white/88 p-5 shadow-[0_24px_70px_-55px_rgba(15,23,42,0.72)]"
+              >
+                <div className="inline-flex size-10 items-center justify-center rounded-2xl bg-brand-soft text-brand">
+                  <item.Icon className="size-5" />
+                </div>
+                <p className="mt-4 text-sm font-medium text-slate-500">
+                  {item.label}
+                </p>
+                <p className="mt-2 font-heading text-2xl font-semibold text-slate-950">
+                  {item.value}
+                </p>
+              </article>
+            ))}
+          </section>
+
+          <section className="rounded-[2rem] border border-dashed border-slate-300 bg-white/72 p-6 shadow-[0_25px_80px_-60px_rgba(15,23,42,0.7)]">
+            <div className="inline-flex size-12 items-center justify-center rounded-2xl bg-slate-950 text-white">
+              <Target className="size-6" />
+            </div>
+            <h2 className="mt-5 font-heading text-2xl font-semibold text-slate-950">
+              Sprint execution comes next
+            </h2>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
+              This placeholder confirms project-scoped sprint routing and RLS
+              reads. User story CRUD, Kanban data, drag-and-drop, charts, risks,
+              and AI actions remain out of scope for Issue #12.
+            </p>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(app)/projects/[projectId]/sprints/actions.ts
+++ b/src/app/(app)/projects/[projectId]/sprints/actions.ts
@@ -1,0 +1,118 @@
+"use server";
+
+import { randomUUID } from "node:crypto";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { sprintFormSchema } from "@/lib/validators/sprint";
+import { createClient } from "@/utils/supabase/server";
+
+function getString(formData: FormData, key: string) {
+  const value = formData.get(key);
+  return typeof value === "string" ? value : "";
+}
+
+function redirectWithSprintError(projectId: string, message: string): never {
+  redirect(
+    `/projects/${projectId}/sprints/new?error=${encodeURIComponent(message)}`,
+  );
+}
+
+function getSprintCreateErrorMessage(message: string) {
+  const normalized = message.toLowerCase();
+
+  if (
+    normalized.includes("start_date") ||
+    normalized.includes("end_date") ||
+    normalized.includes("schema cache") ||
+    normalized.includes("column")
+  ) {
+    return "The sprints table is missing the Issue #12 start_date or end_date columns. Apply the latest Supabase schema before creating sprints.";
+  }
+
+  if (
+    normalized.includes("sprints_status_check") ||
+    normalized.includes("violates check constraint")
+  ) {
+    return "The selected sprint status is not supported by the current sprints table schema.";
+  }
+
+  if (normalized.includes("duplicate") || normalized.includes("unique")) {
+    return "A sprint with that name already exists in this project.";
+  }
+
+  if (normalized.includes("row-level security")) {
+    return "Supabase blocked sprint creation. Confirm you are a project member and the sprint RLS policies are applied.";
+  }
+
+  if (normalized.includes("foreign key")) {
+    return "This project could not be linked to the sprint. Confirm the project exists and try again.";
+  }
+
+  return "Unable to create sprint. Check the form and try again.";
+}
+
+export async function createSprint(formData: FormData) {
+  const projectId = getString(formData, "projectId");
+
+  if (!projectId) {
+    redirect("/projects");
+  }
+
+  const parsed = sprintFormSchema.safeParse({
+    name: getString(formData, "name"),
+    goal: getString(formData, "goal"),
+    start_date: getString(formData, "start_date"),
+    end_date: getString(formData, "end_date"),
+    status: getString(formData, "status"),
+  });
+
+  if (!parsed.success) {
+    redirectWithSprintError(
+      projectId,
+      parsed.error.issues[0]?.message ?? "Enter valid sprint details.",
+    );
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { data: project, error: projectError } = await supabase
+    .from("projects")
+    .select("id")
+    .eq("id", projectId)
+    .maybeSingle();
+
+  if (projectError || !project) {
+    redirectWithSprintError(
+      projectId,
+      "Project not found or you do not have access to create sprints.",
+    );
+  }
+
+  const sprintId = randomUUID();
+  const { error } = await supabase.from("sprints").insert({
+    id: sprintId,
+    project_id: projectId,
+    name: parsed.data.name,
+    goal: parsed.data.goal,
+    start_date: parsed.data.start_date,
+    end_date: parsed.data.end_date,
+    status: parsed.data.status,
+  });
+
+  if (error) {
+    redirectWithSprintError(projectId, getSprintCreateErrorMessage(error.message));
+  }
+
+  revalidatePath("/dashboard");
+  revalidatePath(`/projects/${projectId}`);
+  redirect(`/projects/${projectId}/sprints/${sprintId}`);
+}

--- a/src/app/(app)/projects/[projectId]/sprints/new/page.tsx
+++ b/src/app/(app)/projects/[projectId]/sprints/new/page.tsx
@@ -1,0 +1,103 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft, TimerReset } from "lucide-react";
+import { notFound, redirect } from "next/navigation";
+
+import { AppSidebar } from "@/components/app/app-sidebar";
+import { SprintForm } from "@/components/sprints/sprint-form";
+import { createClient } from "@/utils/supabase/server";
+
+export const metadata: Metadata = {
+  title: "New sprint",
+  description: "Create a Minavolve sprint.",
+};
+
+type NewSprintPageProps = {
+  params: Promise<{
+    projectId: string;
+  }>;
+  searchParams: Promise<{
+    error?: string | string[];
+  }>;
+};
+
+type SprintProject = {
+  id: string;
+  name: string;
+  project_key: string;
+};
+
+function getSearchParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export default async function NewSprintPage({
+  params,
+  searchParams,
+}: NewSprintPageProps) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { projectId } = await params;
+  const { data: project, error: projectError } = await supabase
+    .from("projects")
+    .select("id,name,project_key")
+    .eq("id", projectId)
+    .maybeSingle();
+
+  if (projectError || !project) {
+    notFound();
+  }
+
+  const typedProject = project as SprintProject;
+  const query = await searchParams;
+  const error = getSearchParam(query.error);
+
+  return (
+    <main className="min-h-screen px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto flex w-full max-w-[1540px] flex-col gap-6 lg:flex-row">
+        <div className="lg:w-72 lg:shrink-0">
+          <AppSidebar activeHref="/projects" />
+        </div>
+
+        <div className="min-w-0 flex-1 space-y-6">
+          <Link
+            href={`/projects/${typedProject.id}`}
+            className="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition-colors hover:text-slate-950"
+          >
+            <ArrowLeft className="size-4" />
+            Back to project
+          </Link>
+
+          <header className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6">
+            <div className="flex items-start gap-4">
+              <div className="inline-flex size-12 items-center justify-center rounded-2xl bg-slate-950 text-white">
+                <TimerReset className="size-6" />
+              </div>
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-brand">
+                  {typedProject.project_key} sprint setup
+                </p>
+                <h1 className="mt-2 font-heading text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                  New sprint
+                </h1>
+                <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+                  Create a sprint inside {typedProject.name}. Sprint work stays
+                  scoped to this project through Supabase RLS.
+                </p>
+              </div>
+            </div>
+          </header>
+
+          <SprintForm projectId={typedProject.id} error={error} />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/sprints/sprint-card.tsx
+++ b/src/components/sprints/sprint-card.tsx
@@ -1,0 +1,77 @@
+import Link from "next/link";
+import { ArrowUpRight, CalendarDays, Target } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export type SprintCardSprint = {
+  id: string;
+  project_id: string;
+  name: string;
+  goal: string | null;
+  status: string;
+  start_date: string | null;
+  end_date: string | null;
+  created_at: string;
+};
+
+const statusClasses: Record<string, string> = {
+  planned: "bg-slate-100 text-slate-700",
+  active: "bg-emerald-100 text-emerald-800",
+  completed: "bg-blue-100 text-blue-800",
+  cancelled: "bg-rose-100 text-rose-700",
+};
+
+function formatDate(date: string | null) {
+  if (!date) {
+    return "Not set";
+  }
+
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(`${date}T00:00:00`));
+}
+
+export function SprintCard({ sprint }: { sprint: SprintCardSprint }) {
+  return (
+    <Link
+      href={`/projects/${sprint.project_id}/sprints/${sprint.id}`}
+      className="group block rounded-[1.75rem] border border-white/80 bg-white/88 p-5 shadow-[0_24px_70px_-55px_rgba(15,23,42,0.72)] transition-transform duration-300 hover:-translate-y-1 hover:border-brand/30"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <span
+            className={cn(
+              "rounded-full px-3 py-1.5 text-xs font-semibold capitalize",
+              statusClasses[sprint.status] ?? "bg-slate-100 text-slate-700",
+            )}
+          >
+            {sprint.status}
+          </span>
+          <h3 className="mt-4 font-heading text-xl font-semibold text-slate-950">
+            {sprint.name}
+          </h3>
+        </div>
+
+        <ArrowUpRight className="size-5 shrink-0 text-slate-400 transition-colors group-hover:text-brand" />
+      </div>
+
+      <p className="mt-4 line-clamp-3 min-h-[4.5rem] text-sm leading-6 text-slate-600">
+        {sprint.goal ??
+          "No sprint goal yet. User stories and planning details will be added in later issues."}
+      </p>
+
+      <div className="mt-5 flex flex-wrap gap-2 text-xs font-medium text-slate-600">
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-3 py-1.5">
+          <CalendarDays className="size-3.5" />
+          {formatDate(sprint.start_date)} - {formatDate(sprint.end_date)}
+        </span>
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-brand-soft px-3 py-1.5 text-brand">
+          <Target className="size-3.5" />
+          Sprint workspace
+        </span>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/sprints/sprint-form.tsx
+++ b/src/components/sprints/sprint-form.tsx
@@ -1,0 +1,106 @@
+import { createSprint } from "@/app/(app)/projects/[projectId]/sprints/actions";
+import { Button } from "@/components/ui/button";
+import { sprintStatuses } from "@/lib/validators/sprint";
+
+const statusLabels: Record<(typeof sprintStatuses)[number], string> = {
+  planned: "Planned",
+  active: "Active",
+  completed: "Completed",
+  cancelled: "Cancelled",
+};
+
+type SprintFormProps = {
+  projectId: string;
+  error?: string;
+};
+
+export function SprintForm({ projectId, error }: SprintFormProps) {
+  return (
+    <form
+      action={createSprint}
+      className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6"
+    >
+      <input type="hidden" name="projectId" value={projectId} />
+
+      {error ? (
+        <div className="mb-6 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm leading-6 text-rose-800">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="grid gap-5">
+        <label className="block text-sm font-semibold text-slate-800">
+          Sprint name
+          <input
+            name="name"
+            required
+            minLength={3}
+            maxLength={120}
+            placeholder="Sprint 1 - Launch readiness"
+            className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+          />
+        </label>
+
+        <label className="block text-sm font-semibold text-slate-800">
+          Sprint goal
+          <textarea
+            name="goal"
+            rows={5}
+            maxLength={2000}
+            placeholder="What outcome should this sprint create?"
+            className="mt-2 w-full resize-y rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm leading-6 text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+          />
+        </label>
+
+        <div className="grid gap-5 md:grid-cols-3">
+          <label className="block text-sm font-semibold text-slate-800">
+            Start date
+            <input
+              name="start_date"
+              type="date"
+              className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+            />
+          </label>
+
+          <label className="block text-sm font-semibold text-slate-800">
+            End date
+            <input
+              name="end_date"
+              type="date"
+              className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+            />
+          </label>
+
+          <label className="block text-sm font-semibold text-slate-800">
+            Status
+            <select
+              name="status"
+              defaultValue="planned"
+              className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+            >
+              {sprintStatuses.map((status) => (
+                <option key={status} value={status}>
+                  {statusLabels[status]}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </div>
+
+      <div className="mt-7 flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm leading-6 text-slate-500">
+          User stories, Kanban data, charts, risks, and AI workflows are still
+          intentionally out of scope.
+        </p>
+        <Button
+          type="submit"
+          size="lg"
+          className="h-11 rounded-2xl bg-slate-950 px-5 text-white hover:bg-slate-800"
+        >
+          Create sprint
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/lib/dashboard.ts
+++ b/src/lib/dashboard.ts
@@ -122,9 +122,9 @@ export const dashboardSummaryCards: DashboardSummaryCard[] = [
   },
   {
     label: "Active sprints",
-    value: "2",
-    detail: "Static sprint cycles visible in the planning shell.",
-    trend: "1 sprint closing soon",
+    value: "0",
+    detail: "Supabase sprints currently marked active.",
+    trend: "Create an active sprint to start delivery",
     tone: "green",
     Icon: TimerReset,
   },
@@ -146,20 +146,34 @@ export const dashboardSummaryCards: DashboardSummaryCard[] = [
   },
 ];
 
-export function getDashboardSummaryCards(projectCount: number) {
+export function getDashboardSummaryCards(
+  projectCount: number,
+  activeSprintCount = 0,
+) {
   return dashboardSummaryCards.map((card) => {
-    if (card.label !== "Projects") {
-      return card;
+    if (card.label === "Projects") {
+      return {
+        ...card,
+        value: String(projectCount),
+        trend:
+          projectCount === 1
+            ? "1 project available through RLS"
+            : `${projectCount} projects available through RLS`,
+      };
     }
 
-    return {
-      ...card,
-      value: String(projectCount),
-      trend:
-        projectCount === 1
-          ? "1 project available through RLS"
-          : `${projectCount} projects available through RLS`,
-    };
+    if (card.label === "Active sprints") {
+      return {
+        ...card,
+        value: String(activeSprintCount),
+        trend:
+          activeSprintCount === 1
+            ? "1 active sprint available through RLS"
+            : `${activeSprintCount} active sprints available through RLS`,
+      };
+    }
+
+    return card;
   });
 }
 
@@ -352,7 +366,7 @@ export const dashboardFocusItems = [
   },
   {
     label: "Project CRUD foundation",
-    detail: "Projects can be created and listed through Supabase RLS.",
+    detail: "Projects and sprints can be created through Supabase RLS.",
     Icon: Gauge,
   },
   {

--- a/src/lib/validators/sprint.ts
+++ b/src/lib/validators/sprint.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+export const sprintStatuses = [
+  "planned",
+  "active",
+  "completed",
+  "cancelled",
+] as const;
+
+export type SprintStatus = (typeof sprintStatuses)[number];
+
+const optionalDateSchema = z.preprocess((value) => {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}, z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Use a valid date.").nullable());
+
+export const sprintFormSchema = z
+  .object({
+    name: z
+      .string()
+      .trim()
+      .min(3, "Sprint name must be at least 3 characters.")
+      .max(120, "Sprint name must be 120 characters or fewer."),
+    goal: z
+      .string()
+      .trim()
+      .max(2000, "Sprint goal must be 2000 characters or fewer.")
+      .transform((value) => (value.length > 0 ? value : null)),
+    start_date: optionalDateSchema,
+    end_date: optionalDateSchema,
+    status: z.enum(sprintStatuses),
+  })
+  .refine(
+    (sprint) =>
+      !sprint.start_date ||
+      !sprint.end_date ||
+      sprint.end_date >= sprint.start_date,
+    {
+      message: "End date cannot be earlier than start date.",
+      path: ["end_date"],
+    },
+  );
+
+export type SprintFormValues = z.infer<typeof sprintFormSchema>;

--- a/supabase/migrations/20260503000200_align_project_schema.sql
+++ b/supabase/migrations/20260503000200_align_project_schema.sql
@@ -1,0 +1,44 @@
+alter table public.projects
+add column if not exists project_key text;
+
+alter table public.projects
+add column if not exists description text;
+
+alter table public.projects
+add column if not exists status text not null default 'active';
+
+alter table public.projects
+add column if not exists start_date date;
+
+alter table public.projects
+add column if not exists target_end_date date;
+
+alter table public.projects
+add column if not exists updated_at timestamptz not null default now();
+
+update public.projects
+set project_key = upper(left(regexp_replace(coalesce(name, 'PROJECT'), '[^a-zA-Z0-9]', '', 'g'), 10))
+where project_key is null;
+
+alter table public.projects
+alter column project_key set not null;
+
+alter table public.projects
+drop constraint if exists projects_status_check;
+
+alter table public.projects
+add constraint projects_status_check
+check (status in ('active', 'paused', 'completed', 'archived'));
+
+alter table public.projects
+drop constraint if exists projects_owner_key_unique;
+
+alter table public.projects
+add constraint projects_owner_key_unique
+unique (owner_id, project_key);
+
+create index if not exists projects_owner_id_idx
+on public.projects(owner_id);
+
+create index if not exists projects_status_idx
+on public.projects(status);

--- a/supabase/migrations/20260503000300_fix_sprint_date_columns.sql
+++ b/supabase/migrations/20260503000300_fix_sprint_date_columns.sql
@@ -1,0 +1,14 @@
+alter table public.sprints
+add column if not exists start_date date,
+add column if not exists end_date date;
+
+alter table public.sprints
+drop constraint if exists sprints_date_order;
+
+alter table public.sprints
+add constraint sprints_date_order
+check (
+  start_date is null
+  or end_date is null
+  or end_date >= start_date
+);


### PR DESCRIPTION
## Summary

This PR implements sprint creation and sprint listing inside Minavolve project workspaces.

## Changes

- Added `/projects/[projectId]/sprints/new` page
- Added `/projects/[projectId]/sprints/[sprintId]` placeholder page
- Added server action for creating sprints
- Added sprint form validation with zod
- Added reusable sprint form component
- Added reusable sprint card component
- Updated project workspace to display project-specific sprints
- Added sprint empty state
- Added New sprint navigation from project workspace
- Optionally updated dashboard active sprint summary
- Updated README current status

## Testing

- Ran `npm run lint`
- Ran `npm run dev`
- Logged in with a test user
- Verified `/projects` still lists projects
- Opened an existing project workspace
- Verified sprint empty state appears
- Created a sprint through `/projects/[projectId]/sprints/new`
- Verified sprint row appears in Supabase `sprints`
- Verified sprint `project_id` matches the selected project
- Verified sprint appears in the correct project workspace
- Verified sprint detail placeholder page loads
- Verified invalid sprint form input shows errors
- Verified logged-out users cannot access sprint/project routes
- Verified `/`, `/login`, `/register`, `/dashboard`, and `/projects` still work

Closes Issue #12 