### PR TITLE
feat(stories): add user story creation and listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Minavolve
 
-Minavolve is an Agile sprint board product concept with room for an AI assistant. This repository currently ships a polished landing page, Supabase email/password authentication, an authenticated dashboard layout, and initial Supabase-backed project and sprint creation/listing that later issues can extend with stories, drag-and-drop interactions, and AI workflows.
+Minavolve is an Agile sprint board product concept with room for an AI assistant. This repository currently ships a polished landing page, Supabase email/password authentication, an authenticated dashboard layout, and initial Supabase-backed project, sprint, and user story creation/listing that later issues can extend with drag-and-drop interactions and AI workflows.
 
 ## What this issue includes
 
@@ -12,6 +12,7 @@ Minavolve is an Agile sprint board product concept with room for an AI assistant
 - Authenticated dashboard layout with sidebar navigation, top bar, static summary metrics, placeholder work sections, and a five-column Kanban preview
 - Authenticated project listing, project creation, and a basic project workspace placeholder backed by Supabase RLS
 - Project-scoped sprint listing, sprint creation, and a basic sprint workspace placeholder backed by Supabase RLS
+- Project-scoped user story listing, story creation, optional sprint assignment, and a basic story workspace placeholder backed by Supabase RLS
 - Starter environment variable documentation in `.env.example`
 - Initial Supabase schema migration for projects, sprints, stories, risks, AI generations, activity, memberships, and profiles
 
@@ -19,7 +20,7 @@ Minavolve is an Agile sprint board product concept with room for an AI assistant
 
 - No project editing or deletion
 - No sprint editing or deletion
-- No user story CRUD
+- No user story editing or deletion
 - No drag-and-drop board behavior
 - No charts or risk register CRUD
 - No AI API routes or provider integration
@@ -67,6 +68,7 @@ Minavolve is an Agile sprint board product concept with room for an AI assistant
    - `http://localhost:3000/projects`
    - `http://localhost:3000/projects/new`
    - `http://localhost:3000/projects/[projectId]/sprints/new`
+   - `http://localhost:3000/projects/[projectId]/stories/new`
 
 ## Linting
 
@@ -87,6 +89,8 @@ npm run lint
 - `/projects/[projectId]`: protected project workspace with project-scoped sprint list
 - `/projects/[projectId]/sprints/new`: protected sprint creation form
 - `/projects/[projectId]/sprints/[sprintId]`: protected sprint workspace placeholder
+- `/projects/[projectId]/stories/new`: protected user story creation form
+- `/projects/[projectId]/stories/[storyId]`: protected user story workspace placeholder
 
 ## Dashboard status
 
@@ -94,11 +98,11 @@ Issue #8 adds the authenticated dashboard shell. The page keeps the existing ser
 
 Current dashboard content is intentionally static:
 
-- Summary cards for projects, active sprints, user stories, and open risks. Project and active sprint counts are read from Supabase when available.
+- Summary cards for projects, active sprints, user stories, and open risks. Project, active sprint, and user story counts are read from Supabase when available.
 - Placeholder sections for recent projects, sprint planning, Kanban preview, risk register, delivery analytics, and AI assistant
 - A visual Kanban preview with Backlog, To Do, In Progress, Review, and Done columns
 
-Story management, drag-and-drop, charts, risk CRUD, and AI provider calls remain out of scope for this issue.
+Drag-and-drop, Kanban movement, charts, risk CRUD, and AI provider calls remain out of scope for this issue.
 
 ## Project setup status
 
@@ -127,6 +131,22 @@ Issue #12 adds initial sprint CRUD foundation:
 Sprint form fields are `name`, `goal`, `start_date`, `end_date`, and `status`. The current implementation assumes the Supabase cloud schema includes these Issue #12 columns.
 
 If sprint creation or listing returns a missing `start_date` or `end_date` message, update the Supabase cloud `public.sprints` table before retesting sprint workflows.
+
+## User story setup status
+
+Issue #14 adds initial user story CRUD foundation:
+
+- Project workspaces read stories from `public.user_stories` where `project_id` matches the current project route.
+- `/projects/[projectId]/stories/new` validates story input with Zod and creates rows in `public.user_stories`.
+- Story creation sets `project_id` from the route parameter and can optionally set `sprint_id` to a sprint that belongs to the current project.
+- Acceptance criteria are stored as a text array by splitting the multiline textarea into trimmed non-empty lines.
+- Successful story creation redirects to `/projects/[projectId]/stories/[storyId]`.
+- Sprint detail pages show stories linked to that sprint when the schema supports the Issue #14 fields.
+- The dashboard user story count is read from Supabase when available.
+
+Story form fields are `title`, `description`, `acceptance_criteria`, `story_points`, `priority`, `status`, and optional `sprint_id`. The current implementation assumes the Supabase cloud schema includes these Issue #14 columns.
+
+If story creation or listing returns a missing `acceptance_criteria` or `story_points` message, update the Supabase cloud `public.user_stories` table before retesting story workflows.
 
 ## Environment variables
 

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -43,9 +43,13 @@ export default async function DashboardPage() {
     .from("sprints")
     .select("id", { count: "exact", head: true })
     .eq("status", "active");
+  const { count: userStoryCount } = await supabase
+    .from("user_stories")
+    .select("id", { count: "exact", head: true });
   const summaryCards = getDashboardSummaryCards(
     projectCount ?? 0,
     activeSprintCount ?? 0,
+    userStoryCount ?? 0,
   );
 
   return (

--- a/src/app/(app)/projects/[projectId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/page.tsx
@@ -5,6 +5,8 @@ import {
   CalendarDays,
   ClipboardList,
   FolderKanban,
+  MessageSquarePlus,
+  MessageSquareText,
   Plus,
   ShieldAlert,
   TimerReset,
@@ -16,6 +18,10 @@ import {
   SprintCard,
   type SprintCardSprint,
 } from "@/components/sprints/sprint-card";
+import {
+  StoryCard,
+  type StoryCardStory,
+} from "@/components/stories/story-card";
 import { Button } from "@/components/ui/button";
 import { createClient } from "@/utils/supabase/server";
 
@@ -55,6 +61,21 @@ function getSprintListError(message: string) {
   }
 
   return "Unable to load sprints for this project right now.";
+}
+
+function getStoryListError(message: string) {
+  const normalized = message.toLowerCase();
+
+  if (
+    normalized.includes("acceptance_criteria") ||
+    normalized.includes("story_points") ||
+    normalized.includes("schema cache") ||
+    normalized.includes("column")
+  ) {
+    return "The user_stories table is missing Issue #14 story columns. Apply the latest Supabase schema before listing stories.";
+  }
+
+  return "Unable to load stories for this project right now.";
 }
 
 function formatDate(date: string | null) {
@@ -101,6 +122,22 @@ export default async function ProjectWorkspacePage({
     .eq("project_id", projectId)
     .order("created_at", { ascending: false });
   const sprintRows = (sprints ?? []) as SprintCardSprint[];
+  const sprintNameById = new Map(
+    sprintRows.map((sprint) => [sprint.id, sprint.name]),
+  );
+  const { data: stories, error: storiesError } = await supabase
+    .from("user_stories")
+    .select(
+      "id,project_id,sprint_id,title,description,acceptance_criteria,story_points,priority,status,created_at",
+    )
+    .eq("project_id", projectId)
+    .order("created_at", { ascending: false });
+  const storyRows = ((stories ?? []) as StoryCardStory[]).map((story) => ({
+    ...story,
+    sprint_name: story.sprint_id
+      ? (sprintNameById.get(story.sprint_id) ?? "Sprint unavailable")
+      : null,
+  }));
 
   return (
     <main className="min-h-screen px-4 py-6 sm:px-6 lg:px-8">
@@ -259,6 +296,69 @@ export default async function ProjectWorkspacePage({
                 trigger when a project is inserted.
               </div>
             </article>
+          </section>
+
+          <section className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-brand">
+                  Backlog
+                </p>
+                <h2 className="mt-2 font-heading text-2xl font-semibold text-slate-950">
+                  User stories
+                </h2>
+                <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+                  Stories are scoped to this project and can optionally be
+                  assigned to one of the project sprints.
+                </p>
+              </div>
+              <Button
+                asChild
+                size="lg"
+                className="h-10 rounded-2xl bg-slate-950 px-4 text-white hover:bg-slate-800"
+              >
+                <Link href={`/projects/${typedProject.id}/stories/new`}>
+                  <MessageSquarePlus className="size-4" />
+                  New story
+                </Link>
+              </Button>
+            </div>
+
+            {storiesError ? (
+              <div className="mt-6 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm leading-6 text-rose-800">
+                {getStoryListError(storiesError.message)}
+              </div>
+            ) : storyRows.length > 0 ? (
+              <div className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                {storyRows.map((story) => (
+                  <StoryCard key={story.id} story={story} />
+                ))}
+              </div>
+            ) : (
+              <div className="mt-6 rounded-[1.75rem] border border-dashed border-slate-300 bg-slate-50/80 p-6 text-center">
+                <div className="mx-auto inline-flex size-12 items-center justify-center rounded-2xl bg-brand-soft text-brand">
+                  <MessageSquareText className="size-6" />
+                </div>
+                <h3 className="mt-4 font-heading text-2xl font-semibold text-slate-950">
+                  No stories yet
+                </h3>
+                <p className="mx-auto mt-2 max-w-xl text-sm leading-6 text-slate-600">
+                  Create the first user story for this project. Kanban movement,
+                  drag-and-drop, risks, charts, and AI support will connect to
+                  stories in later issues.
+                </p>
+                <Button
+                  asChild
+                  size="lg"
+                  className="mt-6 h-11 rounded-2xl bg-slate-950 px-5 text-white hover:bg-slate-800"
+                >
+                  <Link href={`/projects/${typedProject.id}/stories/new`}>
+                    <MessageSquarePlus className="size-4" />
+                    Create first story
+                  </Link>
+                </Button>
+              </div>
+            )}
           </section>
         </div>
       </div>

--- a/src/app/(app)/projects/[projectId]/sprints/[sprintId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/sprints/[sprintId]/page.tsx
@@ -5,11 +5,18 @@ import {
   CalendarDays,
   ClipboardList,
   Columns3,
+  MessageSquarePlus,
+  MessageSquareText,
   Target,
 } from "lucide-react";
 import { notFound, redirect } from "next/navigation";
 
 import { AppSidebar } from "@/components/app/app-sidebar";
+import {
+  StoryCard,
+  type StoryCardStory,
+} from "@/components/stories/story-card";
+import { Button } from "@/components/ui/button";
 import { createClient } from "@/utils/supabase/server";
 
 export const metadata: Metadata = {
@@ -41,6 +48,21 @@ type SprintDetail = {
   created_at: string;
   updated_at: string;
 };
+
+function getStoryListError(message: string) {
+  const normalized = message.toLowerCase();
+
+  if (
+    normalized.includes("acceptance_criteria") ||
+    normalized.includes("story_points") ||
+    normalized.includes("schema cache") ||
+    normalized.includes("column")
+  ) {
+    return "The user_stories table is missing Issue #14 story columns. Apply the latest Supabase schema before listing stories.";
+  }
+
+  return "Unable to load stories for this sprint right now.";
+}
 
 function formatDate(date: string | null) {
   if (!date) {
@@ -90,6 +112,18 @@ export default async function SprintDetailPage({
 
   const typedProject = project as SprintProject;
   const typedSprint = sprint as SprintDetail;
+  const { data: stories, error: storiesError } = await supabase
+    .from("user_stories")
+    .select(
+      "id,project_id,sprint_id,title,description,acceptance_criteria,story_points,priority,status,created_at",
+    )
+    .eq("project_id", projectId)
+    .eq("sprint_id", sprintId)
+    .order("created_at", { ascending: false });
+  const storyRows = ((stories ?? []) as StoryCardStory[]).map((story) => ({
+    ...story,
+    sprint_name: typedSprint.name,
+  }));
 
   return (
     <main className="min-h-screen px-4 py-6 sm:px-6 lg:px-8">
@@ -122,7 +156,7 @@ export default async function SprintDetailPage({
                   </h1>
                   <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
                     {typedSprint.goal ??
-                      "No sprint goal yet. User stories, Kanban cards, and delivery metrics will be connected in later issues."}
+                      "No sprint goal yet. Linked user stories can now appear below when assigned to this sprint."}
                   </p>
                 </div>
               </div>
@@ -177,9 +211,62 @@ export default async function SprintDetailPage({
             </h2>
             <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
               This placeholder confirms project-scoped sprint routing and RLS
-              reads. User story CRUD, Kanban data, drag-and-drop, charts, risks,
-              and AI actions remain out of scope for Issue #12.
+              reads. Story listing is available below; Kanban data,
+              drag-and-drop, charts, risks, and AI actions remain out of scope
+              for Issue #14.
             </p>
+          </section>
+
+          <section className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-brand">
+                  Sprint backlog
+                </p>
+                <h2 className="mt-2 font-heading text-2xl font-semibold text-slate-950">
+                  Linked stories
+                </h2>
+                <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+                  Stories shown here are scoped to this project and assigned to
+                  this sprint.
+                </p>
+              </div>
+              <Button
+                asChild
+                size="lg"
+                className="h-10 rounded-2xl bg-slate-950 px-4 text-white hover:bg-slate-800"
+              >
+                <Link href={`/projects/${typedProject.id}/stories/new`}>
+                  <MessageSquarePlus className="size-4" />
+                  New story
+                </Link>
+              </Button>
+            </div>
+
+            {storiesError ? (
+              <div className="mt-6 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm leading-6 text-rose-800">
+                {getStoryListError(storiesError.message)}
+              </div>
+            ) : storyRows.length > 0 ? (
+              <div className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                {storyRows.map((story) => (
+                  <StoryCard key={story.id} story={story} />
+                ))}
+              </div>
+            ) : (
+              <div className="mt-6 rounded-[1.75rem] border border-dashed border-slate-300 bg-slate-50/80 p-6 text-center">
+                <div className="mx-auto inline-flex size-12 items-center justify-center rounded-2xl bg-brand-soft text-brand">
+                  <MessageSquareText className="size-6" />
+                </div>
+                <h3 className="mt-4 font-heading text-2xl font-semibold text-slate-950">
+                  No stories linked to this sprint
+                </h3>
+                <p className="mx-auto mt-2 max-w-xl text-sm leading-6 text-slate-600">
+                  Create a story from the project workspace and choose this
+                  sprint to link it here.
+                </p>
+              </div>
+            )}
           </section>
         </div>
       </div>

--- a/src/app/(app)/projects/[projectId]/stories/[storyId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/stories/[storyId]/page.tsx
@@ -1,0 +1,212 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  ArrowLeft,
+  CheckSquare,
+  ClipboardList,
+  Flag,
+  Gauge,
+  MessageSquareText,
+} from "lucide-react";
+import { notFound, redirect } from "next/navigation";
+
+import { AppSidebar } from "@/components/app/app-sidebar";
+import { createClient } from "@/utils/supabase/server";
+
+export const metadata: Metadata = {
+  title: "Story workspace",
+  description: "Minavolve user story workspace placeholder.",
+};
+
+type StoryDetailPageProps = {
+  params: Promise<{
+    projectId: string;
+    storyId: string;
+  }>;
+};
+
+type StoryProject = {
+  id: string;
+  name: string;
+  project_key: string;
+};
+
+type StoryDetail = {
+  id: string;
+  project_id: string;
+  sprint_id: string | null;
+  title: string;
+  description: string | null;
+  acceptance_criteria: string[] | null;
+  story_points: number;
+  priority: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+};
+
+type StorySprint = {
+  id: string;
+  name: string;
+} | null;
+
+export default async function StoryDetailPage({
+  params,
+}: StoryDetailPageProps) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { projectId, storyId } = await params;
+  const [{ data: project, error: projectError }, { data: story, error }] =
+    await Promise.all([
+      supabase
+        .from("projects")
+        .select("id,name,project_key")
+        .eq("id", projectId)
+        .maybeSingle(),
+      supabase
+        .from("user_stories")
+        .select(
+          "id,project_id,sprint_id,title,description,acceptance_criteria,story_points,priority,status,created_at,updated_at",
+        )
+        .eq("project_id", projectId)
+        .eq("id", storyId)
+        .maybeSingle(),
+    ]);
+
+  if (projectError || error || !project || !story) {
+    notFound();
+  }
+
+  const typedProject = project as StoryProject;
+  const typedStory = story as StoryDetail;
+  let sprint: StorySprint = null;
+
+  if (typedStory.sprint_id) {
+    const { data } = await supabase
+      .from("sprints")
+      .select("id,name")
+      .eq("project_id", projectId)
+      .eq("id", typedStory.sprint_id)
+      .maybeSingle();
+
+    sprint = data as StorySprint;
+  }
+
+  const criteria = typedStory.acceptance_criteria ?? [];
+
+  return (
+    <main className="min-h-screen px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto flex w-full max-w-[1540px] flex-col gap-6 lg:flex-row">
+        <div className="lg:w-72 lg:shrink-0">
+          <AppSidebar activeHref="/projects" />
+        </div>
+
+        <div className="min-w-0 flex-1 space-y-6">
+          <Link
+            href={`/projects/${typedProject.id}`}
+            className="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition-colors hover:text-slate-950"
+          >
+            <ArrowLeft className="size-4" />
+            Back to {typedProject.name}
+          </Link>
+
+          <header className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6">
+            <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
+              <div className="flex items-start gap-4">
+                <div className="inline-flex size-14 items-center justify-center rounded-3xl bg-slate-950 text-white">
+                  <MessageSquareText className="size-7" />
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-brand">
+                    {typedProject.project_key} story workspace
+                  </p>
+                  <h1 className="mt-2 font-heading text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                    {typedStory.title}
+                  </h1>
+                  <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
+                    {typedStory.description ??
+                      "No story description yet. Kanban movement and story editing will be added in later issues."}
+                  </p>
+                </div>
+              </div>
+
+              <span className="h-fit rounded-full bg-brand-soft px-4 py-2 text-sm font-semibold capitalize text-brand">
+                {typedStory.status.replaceAll("_", " ")}
+              </span>
+            </div>
+          </header>
+
+          <section className="grid gap-5 md:grid-cols-4">
+            {[
+              {
+                label: "Story points",
+                value: String(typedStory.story_points),
+                Icon: Gauge,
+              },
+              {
+                label: "Priority",
+                value: typedStory.priority,
+                Icon: Flag,
+              },
+              {
+                label: "Sprint",
+                value: sprint?.name ?? "No sprint",
+                Icon: ClipboardList,
+              },
+              {
+                label: "Criteria",
+                value: String(criteria.length),
+                Icon: CheckSquare,
+              },
+            ].map((item) => (
+              <article
+                key={item.label}
+                className="rounded-[1.75rem] border border-white/80 bg-white/88 p-5 shadow-[0_24px_70px_-55px_rgba(15,23,42,0.72)]"
+              >
+                <div className="inline-flex size-10 items-center justify-center rounded-2xl bg-brand-soft text-brand">
+                  <item.Icon className="size-5" />
+                </div>
+                <p className="mt-4 text-sm font-medium text-slate-500">
+                  {item.label}
+                </p>
+                <p className="mt-2 font-heading text-2xl font-semibold capitalize text-slate-950">
+                  {item.value}
+                </p>
+              </article>
+            ))}
+          </section>
+
+          <section className="rounded-[2rem] border border-white/80 bg-white/88 p-6 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)]">
+            <h2 className="font-heading text-2xl font-semibold text-slate-950">
+              Acceptance criteria
+            </h2>
+            {criteria.length > 0 ? (
+              <ul className="mt-5 space-y-3">
+                {criteria.map((criterion, index) => (
+                  <li
+                    key={`${criterion}-${index}`}
+                    className="flex gap-3 rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-3 text-sm leading-6 text-slate-700"
+                  >
+                    <CheckSquare className="mt-0.5 size-4 shrink-0 text-brand" />
+                    <span>{criterion}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="mt-3 text-sm leading-6 text-slate-600">
+                No acceptance criteria were added for this story.
+              </p>
+            )}
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(app)/projects/[projectId]/stories/actions.ts
+++ b/src/app/(app)/projects/[projectId]/stories/actions.ts
@@ -1,0 +1,146 @@
+"use server";
+
+import { randomUUID } from "node:crypto";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import {
+  parseAcceptanceCriteria,
+  storyFormSchema,
+} from "@/lib/validators/story";
+import { createClient } from "@/utils/supabase/server";
+
+function getString(formData: FormData, key: string) {
+  const value = formData.get(key);
+  return typeof value === "string" ? value : "";
+}
+
+function redirectWithStoryError(projectId: string, message: string): never {
+  redirect(
+    `/projects/${projectId}/stories/new?error=${encodeURIComponent(message)}`,
+  );
+}
+
+function getStoryCreateErrorMessage(message: string) {
+  const normalized = message.toLowerCase();
+
+  if (
+    normalized.includes("acceptance_criteria") ||
+    normalized.includes("story_points") ||
+    normalized.includes("schema cache") ||
+    normalized.includes("column")
+  ) {
+    return "The user_stories table is missing Issue #14 story columns. Apply the latest Supabase schema before creating stories.";
+  }
+
+  if (
+    normalized.includes("user_stories_status_check") ||
+    normalized.includes("user_stories_priority_check") ||
+    normalized.includes("violates check constraint")
+  ) {
+    return "The selected story status or priority is not supported by the current database schema.";
+  }
+
+  if (normalized.includes("row-level security")) {
+    return "Supabase blocked story creation. Confirm you are a project member and the story RLS policies are applied.";
+  }
+
+  if (normalized.includes("foreign key")) {
+    return "The selected project or sprint could not be linked to this story.";
+  }
+
+  return "Unable to create story. Check the form and try again.";
+}
+
+export async function createStory(formData: FormData) {
+  const projectId = getString(formData, "projectId");
+
+  if (!projectId) {
+    redirect("/projects");
+  }
+
+  const parsed = storyFormSchema.safeParse({
+    title: getString(formData, "title"),
+    description: getString(formData, "description"),
+    acceptance_criteria: parseAcceptanceCriteria(
+      formData.get("acceptance_criteria"),
+    ),
+    story_points: getString(formData, "story_points"),
+    priority: getString(formData, "priority"),
+    status: getString(formData, "status"),
+    sprint_id: getString(formData, "sprint_id"),
+  });
+
+  if (!parsed.success) {
+    redirectWithStoryError(
+      projectId,
+      parsed.error.issues[0]?.message ?? "Enter valid story details.",
+    );
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { data: project, error: projectError } = await supabase
+    .from("projects")
+    .select("id")
+    .eq("id", projectId)
+    .maybeSingle();
+
+  if (projectError || !project) {
+    redirectWithStoryError(
+      projectId,
+      "Project not found or you do not have access to create stories.",
+    );
+  }
+
+  if (parsed.data.sprint_id) {
+    const { data: sprint, error: sprintError } = await supabase
+      .from("sprints")
+      .select("id")
+      .eq("id", parsed.data.sprint_id)
+      .eq("project_id", projectId)
+      .maybeSingle();
+
+    if (sprintError || !sprint) {
+      redirectWithStoryError(
+        projectId,
+        "Selected sprint does not belong to this project.",
+      );
+    }
+  }
+
+  const storyId = randomUUID();
+  const { error } = await supabase.from("user_stories").insert({
+    id: storyId,
+    project_id: projectId,
+    sprint_id: parsed.data.sprint_id,
+    title: parsed.data.title,
+    description: parsed.data.description,
+    acceptance_criteria: parsed.data.acceptance_criteria,
+    story_points: parsed.data.story_points,
+    priority: parsed.data.priority,
+    status: parsed.data.status,
+    sort_order: 0,
+  });
+
+  if (error) {
+    redirectWithStoryError(projectId, getStoryCreateErrorMessage(error.message));
+  }
+
+  revalidatePath("/dashboard");
+  revalidatePath(`/projects/${projectId}`);
+
+  if (parsed.data.sprint_id) {
+    revalidatePath(`/projects/${projectId}/sprints/${parsed.data.sprint_id}`);
+  }
+
+  redirect(`/projects/${projectId}/stories/${storyId}`);
+}

--- a/src/app/(app)/projects/[projectId]/stories/new/page.tsx
+++ b/src/app/(app)/projects/[projectId]/stories/new/page.tsx
@@ -1,0 +1,126 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft, MessageSquarePlus } from "lucide-react";
+import { notFound, redirect } from "next/navigation";
+
+import { AppSidebar } from "@/components/app/app-sidebar";
+import {
+  StoryForm,
+  type StorySprintOption,
+} from "@/components/stories/story-form";
+import { createClient } from "@/utils/supabase/server";
+
+export const metadata: Metadata = {
+  title: "New story",
+  description: "Create a Minavolve user story.",
+};
+
+type NewStoryPageProps = {
+  params: Promise<{
+    projectId: string;
+  }>;
+  searchParams: Promise<{
+    error?: string | string[];
+  }>;
+};
+
+type StoryProject = {
+  id: string;
+  name: string;
+  project_key: string;
+};
+
+function getSearchParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export default async function NewStoryPage({
+  params,
+  searchParams,
+}: NewStoryPageProps) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { projectId } = await params;
+  const [{ data: project, error: projectError }, { data: sprints, error }] =
+    await Promise.all([
+      supabase
+        .from("projects")
+        .select("id,name,project_key")
+        .eq("id", projectId)
+        .maybeSingle(),
+      supabase
+        .from("sprints")
+        .select("id,name,status")
+        .eq("project_id", projectId)
+        .order("created_at", { ascending: false }),
+    ]);
+
+  if (projectError || !project) {
+    notFound();
+  }
+
+  const typedProject = project as StoryProject;
+  const sprintOptions = (sprints ?? []) as StorySprintOption[];
+  const query = await searchParams;
+  const actionError = getSearchParam(query.error);
+
+  return (
+    <main className="min-h-screen px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto flex w-full max-w-[1540px] flex-col gap-6 lg:flex-row">
+        <div className="lg:w-72 lg:shrink-0">
+          <AppSidebar activeHref="/projects" />
+        </div>
+
+        <div className="min-w-0 flex-1 space-y-6">
+          <Link
+            href={`/projects/${typedProject.id}`}
+            className="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition-colors hover:text-slate-950"
+          >
+            <ArrowLeft className="size-4" />
+            Back to project
+          </Link>
+
+          <header className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6">
+            <div className="flex items-start gap-4">
+              <div className="inline-flex size-12 items-center justify-center rounded-2xl bg-slate-950 text-white">
+                <MessageSquarePlus className="size-6" />
+              </div>
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-brand">
+                  {typedProject.project_key} story setup
+                </p>
+                <h1 className="mt-2 font-heading text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                  New story
+                </h1>
+                <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+                  Create a project-scoped user story for {typedProject.name}.
+                  Assign it to a sprint now, or leave it in the backlog.
+                </p>
+              </div>
+            </div>
+          </header>
+
+          {error ? (
+            <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm leading-6 text-amber-900">
+              Sprints could not load for assignment. You can still create a
+              backlog story without selecting a sprint.
+            </div>
+          ) : null}
+
+          <StoryForm
+            projectId={typedProject.id}
+            sprints={sprintOptions}
+            error={actionError}
+          />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/stories/story-card.tsx
+++ b/src/components/stories/story-card.tsx
@@ -1,0 +1,93 @@
+import Link from "next/link";
+import { ArrowUpRight, CheckSquare, Flag, Gauge } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export type StoryCardStory = {
+  id: string;
+  project_id: string;
+  sprint_id: string | null;
+  title: string;
+  description: string | null;
+  acceptance_criteria: string[] | null;
+  story_points: number;
+  priority: string;
+  status: string;
+  created_at: string;
+  sprint_name?: string | null;
+};
+
+const statusClasses: Record<string, string> = {
+  backlog: "bg-slate-100 text-slate-700",
+  todo: "bg-blue-100 text-blue-800",
+  in_progress: "bg-cyan-100 text-cyan-900",
+  review: "bg-amber-100 text-amber-900",
+  done: "bg-emerald-100 text-emerald-800",
+};
+
+const priorityClasses: Record<string, string> = {
+  low: "bg-slate-100 text-slate-700",
+  medium: "bg-blue-100 text-blue-800",
+  high: "bg-orange-100 text-orange-800",
+  urgent: "bg-rose-100 text-rose-800",
+};
+
+export function StoryCard({ story }: { story: StoryCardStory }) {
+  const criteriaCount = story.acceptance_criteria?.length ?? 0;
+
+  return (
+    <Link
+      href={`/projects/${story.project_id}/stories/${story.id}`}
+      className="group block rounded-[1.75rem] border border-white/80 bg-white/88 p-5 shadow-[0_24px_70px_-55px_rgba(15,23,42,0.72)] transition-transform duration-300 hover:-translate-y-1 hover:border-brand/30"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <div className="flex flex-wrap gap-2">
+            <span
+              className={cn(
+                "rounded-full px-3 py-1.5 text-xs font-semibold capitalize",
+                statusClasses[story.status] ?? "bg-slate-100 text-slate-700",
+              )}
+            >
+              {story.status.replaceAll("_", " ")}
+            </span>
+            <span
+              className={cn(
+                "rounded-full px-3 py-1.5 text-xs font-semibold capitalize",
+                priorityClasses[story.priority] ??
+                  "bg-slate-100 text-slate-700",
+              )}
+            >
+              {story.priority}
+            </span>
+          </div>
+          <h3 className="mt-4 line-clamp-2 font-heading text-xl font-semibold text-slate-950">
+            {story.title}
+          </h3>
+        </div>
+
+        <ArrowUpRight className="size-5 shrink-0 text-slate-400 transition-colors group-hover:text-brand" />
+      </div>
+
+      <p className="mt-4 line-clamp-3 min-h-[4.5rem] text-sm leading-6 text-slate-600">
+        {story.description ??
+          "No description yet. Add details or acceptance criteria as the workflow matures."}
+      </p>
+
+      <div className="mt-5 flex flex-wrap gap-2 text-xs font-medium text-slate-600">
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-3 py-1.5">
+          <Gauge className="size-3.5" />
+          {story.story_points} pts
+        </span>
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-brand-soft px-3 py-1.5 text-brand">
+          <CheckSquare className="size-3.5" />
+          {criteriaCount} criteria
+        </span>
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-3 py-1.5">
+          <Flag className="size-3.5" />
+          {story.sprint_name ?? "No sprint"}
+        </span>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/stories/story-form.tsx
+++ b/src/components/stories/story-form.tsx
@@ -1,0 +1,160 @@
+import { createStory } from "@/app/(app)/projects/[projectId]/stories/actions";
+import { Button } from "@/components/ui/button";
+import { storyPriorities, storyStatuses } from "@/lib/validators/story";
+
+export type StorySprintOption = {
+  id: string;
+  name: string;
+  status: string;
+};
+
+const priorityLabels: Record<(typeof storyPriorities)[number], string> = {
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  urgent: "Urgent",
+};
+
+const statusLabels: Record<(typeof storyStatuses)[number], string> = {
+  backlog: "Backlog",
+  todo: "To Do",
+  in_progress: "In Progress",
+  review: "Review",
+  done: "Done",
+};
+
+type StoryFormProps = {
+  projectId: string;
+  sprints: StorySprintOption[];
+  error?: string;
+};
+
+export function StoryForm({ projectId, sprints, error }: StoryFormProps) {
+  return (
+    <form
+      action={createStory}
+      className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6"
+    >
+      <input type="hidden" name="projectId" value={projectId} />
+
+      {error ? (
+        <div className="mb-6 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm leading-6 text-rose-800">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="grid gap-5">
+        <label className="block text-sm font-semibold text-slate-800">
+          Story title
+          <input
+            name="title"
+            required
+            minLength={3}
+            maxLength={180}
+            placeholder="As a team member, I can..."
+            className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+          />
+        </label>
+
+        <label className="block text-sm font-semibold text-slate-800">
+          Description
+          <textarea
+            name="description"
+            rows={5}
+            maxLength={4000}
+            placeholder="Describe the context, user need, and expected outcome."
+            className="mt-2 w-full resize-y rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm leading-6 text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+          />
+        </label>
+
+        <label className="block text-sm font-semibold text-slate-800">
+          Acceptance criteria
+          <textarea
+            name="acceptance_criteria"
+            rows={6}
+            placeholder={"Each non-empty line becomes one criterion.\nExample: User sees a success message after saving."}
+            className="mt-2 w-full resize-y rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm leading-6 text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+          />
+          <span className="mt-2 block text-xs font-normal leading-5 text-slate-500">
+            Blank lines are ignored.
+          </span>
+        </label>
+
+        <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-4">
+          <label className="block text-sm font-semibold text-slate-800">
+            Story points
+            <input
+              name="story_points"
+              required
+              type="number"
+              min={1}
+              max={100}
+              defaultValue={3}
+              className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+            />
+          </label>
+
+          <label className="block text-sm font-semibold text-slate-800">
+            Priority
+            <select
+              name="priority"
+              defaultValue="medium"
+              className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+            >
+              {storyPriorities.map((priority) => (
+                <option key={priority} value={priority}>
+                  {priorityLabels[priority]}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="block text-sm font-semibold text-slate-800">
+            Status
+            <select
+              name="status"
+              defaultValue="backlog"
+              className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+            >
+              {storyStatuses.map((status) => (
+                <option key={status} value={status}>
+                  {statusLabels[status]}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="block text-sm font-semibold text-slate-800">
+            Sprint
+            <select
+              name="sprint_id"
+              defaultValue=""
+              className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+            >
+              <option value="">No sprint</option>
+              {sprints.map((sprint) => (
+                <option key={sprint.id} value={sprint.id}>
+                  {sprint.name} ({sprint.status})
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </div>
+
+      <div className="mt-7 flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm leading-6 text-slate-500">
+          Drag-and-drop, Kanban movement, risks, charts, and AI workflows remain
+          out of scope for this issue.
+        </p>
+        <Button
+          type="submit"
+          size="lg"
+          className="h-11 rounded-2xl bg-slate-950 px-5 text-white hover:bg-slate-800"
+        >
+          Create story
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/lib/dashboard.ts
+++ b/src/lib/dashboard.ts
@@ -130,9 +130,9 @@ export const dashboardSummaryCards: DashboardSummaryCard[] = [
   },
   {
     label: "User stories",
-    value: "28",
-    detail: "Placeholder backlog volume for the future board.",
-    trend: "9 shaped for next sprint",
+    value: "0",
+    detail: "Supabase user stories visible to the current user.",
+    trend: "Create stories from a project workspace",
     tone: "amber",
     Icon: MessageSquareText,
   },
@@ -149,6 +149,7 @@ export const dashboardSummaryCards: DashboardSummaryCard[] = [
 export function getDashboardSummaryCards(
   projectCount: number,
   activeSprintCount = 0,
+  userStoryCount = 0,
 ) {
   return dashboardSummaryCards.map((card) => {
     if (card.label === "Projects") {
@@ -170,6 +171,17 @@ export function getDashboardSummaryCards(
           activeSprintCount === 1
             ? "1 active sprint available through RLS"
             : `${activeSprintCount} active sprints available through RLS`,
+      };
+    }
+
+    if (card.label === "User stories") {
+      return {
+        ...card,
+        value: String(userStoryCount),
+        trend:
+          userStoryCount === 1
+            ? "1 story available through RLS"
+            : `${userStoryCount} stories available through RLS`,
       };
     }
 
@@ -366,7 +378,7 @@ export const dashboardFocusItems = [
   },
   {
     label: "Project CRUD foundation",
-    detail: "Projects and sprints can be created through Supabase RLS.",
+    detail: "Projects, sprints, and stories can be created through Supabase RLS.",
     Icon: Gauge,
   },
   {

--- a/src/lib/validators/story.ts
+++ b/src/lib/validators/story.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+
+export const storyPriorities = ["low", "medium", "high", "urgent"] as const;
+
+export const storyStatuses = [
+  "backlog",
+  "todo",
+  "in_progress",
+  "review",
+  "done",
+] as const;
+
+export type StoryPriority = (typeof storyPriorities)[number];
+export type StoryStatus = (typeof storyStatuses)[number];
+
+function toOptionalUuid(value: unknown) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function parseAcceptanceCriteria(value: FormDataEntryValue | null) {
+  if (typeof value !== "string") {
+    return [];
+  }
+
+  return value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+export const storyFormSchema = z.object({
+  title: z
+    .string()
+    .trim()
+    .min(3, "Story title must be at least 3 characters.")
+    .max(180, "Story title must be 180 characters or fewer."),
+  description: z
+    .string()
+    .trim()
+    .max(4000, "Description must be 4000 characters or fewer.")
+    .transform((value) => (value.length > 0 ? value : null)),
+  acceptance_criteria: z
+    .array(z.string().min(1))
+    .max(25, "Use 25 acceptance criteria or fewer."),
+  story_points: z.coerce
+    .number({
+      error: "Story points must be a number.",
+    })
+    .int("Story points must be a whole number.")
+    .min(1, "Story points must be at least 1.")
+    .max(100, "Story points must be 100 or fewer."),
+  priority: z.enum(storyPriorities),
+  status: z.enum(storyStatuses),
+  sprint_id: z.preprocess(
+    toOptionalUuid,
+    z.uuid("Select a valid sprint.").nullable(),
+  ),
+});
+
+export type StoryFormValues = z.infer<typeof storyFormSchema>;

--- a/supabase/migrations/20260503000400_align_user_stories_schema.sql
+++ b/supabase/migrations/20260503000400_align_user_stories_schema.sql
@@ -1,0 +1,80 @@
+-- Align user_stories table with Issue #14 user story creation/listing feature.
+-- Records the required schema for story CRUD, sprint assignment, and acceptance criteria.
+
+alter table public.user_stories
+add column if not exists sprint_id uuid;
+
+alter table public.user_stories
+add column if not exists description text;
+
+alter table public.user_stories
+add column if not exists acceptance_criteria text[] not null default '{}';
+
+alter table public.user_stories
+add column if not exists story_points integer not null default 1;
+
+alter table public.user_stories
+add column if not exists priority text not null default 'medium';
+
+alter table public.user_stories
+add column if not exists status text not null default 'backlog';
+
+alter table public.user_stories
+add column if not exists sort_order numeric not null default 0;
+
+alter table public.user_stories
+add column if not exists assignee_id uuid;
+
+alter table public.user_stories
+add column if not exists updated_at timestamptz not null default now();
+
+alter table public.user_stories
+drop constraint if exists user_stories_sprint_id_fkey;
+
+alter table public.user_stories
+add constraint user_stories_sprint_id_fkey
+foreign key (sprint_id)
+references public.sprints(id)
+on delete set null;
+
+alter table public.user_stories
+drop constraint if exists user_stories_assignee_id_fkey;
+
+alter table public.user_stories
+add constraint user_stories_assignee_id_fkey
+foreign key (assignee_id)
+references public.profiles(id)
+on delete set null;
+
+alter table public.user_stories
+drop constraint if exists user_stories_story_points_check;
+
+alter table public.user_stories
+add constraint user_stories_story_points_check
+check (story_points between 1 and 100);
+
+alter table public.user_stories
+drop constraint if exists user_stories_priority_check;
+
+alter table public.user_stories
+add constraint user_stories_priority_check
+check (priority in ('low', 'medium', 'high', 'urgent'));
+
+alter table public.user_stories
+drop constraint if exists user_stories_status_check;
+
+alter table public.user_stories
+add constraint user_stories_status_check
+check (status in ('backlog', 'todo', 'in_progress', 'review', 'done'));
+
+create index if not exists user_stories_project_id_idx
+on public.user_stories(project_id);
+
+create index if not exists user_stories_sprint_id_idx
+on public.user_stories(sprint_id);
+
+create index if not exists user_stories_status_idx
+on public.user_stories(status);
+
+create index if not exists user_stories_assignee_id_idx
+on public.user_stories(assignee_id);


### PR DESCRIPTION
## Summary

This PR implements user story creation and listing inside Minavolve project workspaces.

## Changes

- Added `/projects/[projectId]/stories/new` page
- Added `/projects/[projectId]/stories/[storyId]` placeholder page
- Added server action for creating user stories
- Added story form validation with zod
- Added reusable story form component
- Added reusable story card component
- Updated project workspace to display project-specific user stories
- Added optional sprint assignment for stories
- Added story empty state
- Added New story navigation from project workspace
- Optionally updated dashboard user story summary
- Updated sprint detail placeholder to show linked stories if practical
- Updated README current status

## Testing

- Ran `npm run lint`
- Ran `npm run dev`
- Logged in with a test user
- Verified `/projects` still lists projects
- Opened an existing project workspace
- Verified sprint section still works
- Verified story empty state appears
- Created a story without a sprint
- Created a story linked to an existing sprint
- Verified story rows appear in Supabase `user_stories`
- Verified story `project_id` matches the selected project
- Verified sprint-linked story has correct `sprint_id`
- Verified acceptance criteria are saved as a text array
- Verified stories appear in the correct project workspace
- Verified story detail placeholder page loads
- Verified invalid story form input shows errors
- Verified logged-out users cannot access story/project routes
- Verified `/`, `/login`, `/register`, `/dashboard`, `/projects`, and sprint routes still work

Closes Issue #14 