### PR TITLE
feat(kanban): add basic project board

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Minavolve
 
-Minavolve is an Agile sprint board product concept with room for an AI assistant. This repository currently ships a polished landing page, Supabase email/password authentication, an authenticated dashboard layout, and initial Supabase-backed project, sprint, and user story creation/listing that later issues can extend with drag-and-drop interactions and AI workflows.
+Minavolve is an Agile sprint board product concept with room for an AI assistant. This repository currently ships a polished landing page, Supabase email/password authentication, an authenticated dashboard layout, initial Supabase-backed project/sprint/user story creation and listing, and a basic read-only Kanban board that later issues can extend with drag-and-drop interactions and AI workflows.
 
 ## What this issue includes
 
@@ -13,6 +13,7 @@ Minavolve is an Agile sprint board product concept with room for an AI assistant
 - Authenticated project listing, project creation, and a basic project workspace placeholder backed by Supabase RLS
 - Project-scoped sprint listing, sprint creation, and a basic sprint workspace placeholder backed by Supabase RLS
 - Project-scoped user story listing, story creation, optional sprint assignment, and a basic story workspace placeholder backed by Supabase RLS
+- Project-scoped read-only Kanban board grouped by user story status
 - Starter environment variable documentation in `.env.example`
 - Initial Supabase schema migration for projects, sprints, stories, risks, AI generations, activity, memberships, and profiles
 
@@ -21,7 +22,7 @@ Minavolve is an Agile sprint board product concept with room for an AI assistant
 - No project editing or deletion
 - No sprint editing or deletion
 - No user story editing or deletion
-- No drag-and-drop board behavior
+- No drag-and-drop board behavior or Kanban status updates
 - No charts or risk register CRUD
 - No AI API routes or provider integration
 
@@ -69,6 +70,7 @@ Minavolve is an Agile sprint board product concept with room for an AI assistant
    - `http://localhost:3000/projects/new`
    - `http://localhost:3000/projects/[projectId]/sprints/new`
    - `http://localhost:3000/projects/[projectId]/stories/new`
+   - `http://localhost:3000/projects/[projectId]/kanban`
 
 ## Linting
 
@@ -91,6 +93,7 @@ npm run lint
 - `/projects/[projectId]/sprints/[sprintId]`: protected sprint workspace placeholder
 - `/projects/[projectId]/stories/new`: protected user story creation form
 - `/projects/[projectId]/stories/[storyId]`: protected user story workspace placeholder
+- `/projects/[projectId]/kanban`: protected project-specific Kanban board grouped by story status
 
 ## Dashboard status
 
@@ -100,7 +103,7 @@ Current dashboard content is intentionally static:
 
 - Summary cards for projects, active sprints, user stories, and open risks. Project, active sprint, and user story counts are read from Supabase when available.
 - Placeholder sections for recent projects, sprint planning, Kanban preview, risk register, delivery analytics, and AI assistant
-- A visual Kanban preview with Backlog, To Do, In Progress, Review, and Done columns
+- A visual Kanban preview with Backlog, To Do, In Progress, Review, and Done columns. Project workspaces also include a read-only Kanban board backed by user stories.
 
 Drag-and-drop, Kanban movement, charts, risk CRUD, and AI provider calls remain out of scope for this issue.
 
@@ -147,6 +150,20 @@ Issue #14 adds initial user story CRUD foundation:
 Story form fields are `title`, `description`, `acceptance_criteria`, `story_points`, `priority`, `status`, and optional `sprint_id`. The current implementation assumes the Supabase cloud schema includes these Issue #14 columns.
 
 If story creation or listing returns a missing `acceptance_criteria` or `story_points` message, update the Supabase cloud `public.user_stories` table before retesting story workflows.
+
+## Kanban board status
+
+Issue #16 adds a basic project-specific Kanban board:
+
+- `/projects/[projectId]/kanban` reads user stories from `public.user_stories` for the current project.
+- Stories are grouped into Backlog, To Do, In Progress, Review, and Done columns based on `status`.
+- Cards show title, priority, story points, status, sprint name when linked, and acceptance criteria count.
+- Project workspaces link to the Kanban board, and story detail pages link back to the board.
+- Empty columns show clear empty states.
+
+The board is read-only. Drag-and-drop, sort persistence, and status updates remain out of scope for this issue.
+
+The implementation assumes `public.user_stories.status` and `public.user_stories.sort_order` already exist, as defined in the initial schema, and also uses the Issue #14 story fields such as `acceptance_criteria` and `story_points` for card metadata.
 
 ## Environment variables
 

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -167,7 +167,7 @@ export default async function DashboardPage() {
                 id="kanban-preview"
                 eyebrow="Board"
                 title="Kanban preview"
-                description="The board is intentionally static in this issue. Drag-and-drop and persistence come later."
+                description="Project workspaces now include a read-only Kanban board grouped by story status. This dashboard preview remains static; drag-and-drop and status updates come later."
               >
                 <KanbanPreview />
               </DashboardSection>

--- a/src/app/(app)/projects/[projectId]/kanban/page.tsx
+++ b/src/app/(app)/projects/[projectId]/kanban/page.tsx
@@ -1,0 +1,226 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft, Columns3, MessageSquarePlus } from "lucide-react";
+import { notFound, redirect } from "next/navigation";
+
+import { AppSidebar } from "@/components/app/app-sidebar";
+import { KanbanBoard } from "@/components/kanban/kanban-board";
+import { Button } from "@/components/ui/button";
+import {
+  buildKanbanColumns,
+  getStoryStatusSummary,
+  isKanbanStatus,
+  type KanbanStory,
+} from "@/lib/kanban";
+import { createClient } from "@/utils/supabase/server";
+
+export const metadata: Metadata = {
+  title: "Kanban board",
+  description: "Project-specific Minavolve Kanban board.",
+};
+
+type KanbanPageProps = {
+  params: Promise<{
+    projectId: string;
+  }>;
+};
+
+type KanbanProject = {
+  id: string;
+  name: string;
+  project_key: string;
+  description: string | null;
+};
+
+type SprintLookup = {
+  id: string;
+  name: string;
+};
+
+type RawKanbanStory = {
+  id: string;
+  project_id: string;
+  sprint_id: string | null;
+  title: string;
+  acceptance_criteria: string[] | null;
+  story_points: number | null;
+  priority: string;
+  status: string;
+  sort_order: number | null;
+  created_at: string;
+};
+
+function getKanbanLoadError(message: string) {
+  const normalized = message.toLowerCase();
+
+  if (
+    normalized.includes("status") ||
+    normalized.includes("sort_order") ||
+    normalized.includes("acceptance_criteria") ||
+    normalized.includes("story_points") ||
+    normalized.includes("schema cache") ||
+    normalized.includes("column")
+  ) {
+    return "The user_stories table is missing fields needed for the Kanban board. Confirm status, sort_order, acceptance_criteria, and story_points exist before retesting.";
+  }
+
+  return "Unable to load the Kanban board right now.";
+}
+
+export default async function ProjectKanbanPage({ params }: KanbanPageProps) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { projectId } = await params;
+  const [
+    { data: project, error: projectError },
+    { data: sprints, error: sprintError },
+    { data: stories, error: storyError },
+  ] = await Promise.all([
+    supabase
+      .from("projects")
+      .select("id,name,project_key,description")
+      .eq("id", projectId)
+      .maybeSingle(),
+    supabase
+      .from("sprints")
+      .select("id,name")
+      .eq("project_id", projectId)
+      .order("created_at", { ascending: false }),
+    supabase
+      .from("user_stories")
+      .select(
+        "id,project_id,sprint_id,title,acceptance_criteria,story_points,priority,status,sort_order,created_at",
+      )
+      .eq("project_id", projectId)
+      .in("status", ["backlog", "todo", "in_progress", "review", "done"])
+      .order("sort_order", { ascending: true })
+      .order("created_at", { ascending: true }),
+  ]);
+
+  if (projectError || !project) {
+    notFound();
+  }
+
+  const typedProject = project as KanbanProject;
+  const sprintNameById = new Map(
+    ((sprints ?? []) as SprintLookup[]).map((sprint) => [
+      sprint.id,
+      sprint.name,
+    ]),
+  );
+
+  const kanbanStories = storyError
+    ? []
+    : ((stories ?? []) as RawKanbanStory[]).flatMap<KanbanStory>((story) => {
+        if (!isKanbanStatus(story.status)) {
+          return [];
+        }
+
+        return [
+          {
+            ...story,
+            status: story.status,
+            sprint_name: story.sprint_id
+              ? (sprintNameById.get(story.sprint_id) ?? "Sprint unavailable")
+              : null,
+          },
+        ];
+      });
+
+  const columns = buildKanbanColumns(kanbanStories);
+  const summary = getStoryStatusSummary(kanbanStories);
+
+  return (
+    <main className="min-h-screen px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto flex w-full max-w-[1720px] flex-col gap-6 lg:flex-row">
+        <div className="lg:w-72 lg:shrink-0">
+          <AppSidebar activeHref="/projects" />
+        </div>
+
+        <div className="min-w-0 flex-1 space-y-6">
+          <Link
+            href={`/projects/${typedProject.id}`}
+            className="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition-colors hover:text-slate-950"
+          >
+            <ArrowLeft className="size-4" />
+            Back to project
+          </Link>
+
+          <header className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6">
+            <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
+              <div className="flex items-start gap-4">
+                <div className="inline-flex size-14 items-center justify-center rounded-3xl bg-slate-950 text-white">
+                  <Columns3 className="size-7" />
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-brand">
+                    {typedProject.project_key} board
+                  </p>
+                  <h1 className="mt-2 font-heading text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                    Kanban board
+                  </h1>
+                  <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
+                    A read-only board for {typedProject.name}. Stories are
+                    grouped by status; drag-and-drop and status updates are
+                    intentionally out of scope for this issue.
+                  </p>
+                </div>
+              </div>
+
+              <Button
+                asChild
+                size="lg"
+                className="h-11 rounded-2xl bg-slate-950 px-5 text-white hover:bg-slate-800"
+              >
+                <Link href={`/projects/${typedProject.id}/stories/new`}>
+                  <MessageSquarePlus className="size-4" />
+                  New story
+                </Link>
+              </Button>
+            </div>
+          </header>
+
+          <section className="grid gap-3 md:grid-cols-5" aria-label="Board status summary">
+            {summary.map((item) => (
+              <article
+                key={item.status}
+                className="rounded-[1.25rem] border border-white/80 bg-white/80 p-4 shadow-[0_20px_60px_-50px_rgba(15,23,42,0.7)]"
+              >
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                  {item.label}
+                </p>
+                <p className="mt-2 font-heading text-3xl font-semibold text-slate-950">
+                  {item.count}
+                </p>
+              </article>
+            ))}
+          </section>
+
+          {storyError ? (
+            <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm leading-6 text-rose-800">
+              {getKanbanLoadError(storyError.message)}
+            </div>
+          ) : null}
+
+          {sprintError ? (
+            <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm leading-6 text-amber-900">
+              Sprint names could not load, so story cards may show unavailable
+              sprint labels.
+            </div>
+          ) : null}
+
+          <section className="rounded-[2rem] border border-white/80 bg-white/88 p-4 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-5">
+            <KanbanBoard columns={columns} />
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(app)/projects/[projectId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/page.tsx
@@ -4,6 +4,7 @@ import {
   ArrowLeft,
   CalendarDays,
   ClipboardList,
+  Columns3,
   FolderKanban,
   MessageSquarePlus,
   MessageSquareText,
@@ -175,9 +176,21 @@ export default async function ProjectWorkspacePage({
                 </div>
               </div>
 
-              <span className="h-fit rounded-full bg-brand-soft px-4 py-2 text-sm font-semibold capitalize text-brand">
-                {typedProject.status}
-              </span>
+              <div className="flex flex-col gap-3 sm:flex-row xl:items-center">
+                <span className="h-fit rounded-full bg-brand-soft px-4 py-2 text-sm font-semibold capitalize text-brand">
+                  {typedProject.status}
+                </span>
+                <Button
+                  asChild
+                  size="lg"
+                  className="h-10 rounded-2xl bg-slate-950 px-4 text-white hover:bg-slate-800"
+                >
+                  <Link href={`/projects/${typedProject.id}/kanban`}>
+                    <Columns3 className="size-4" />
+                    Kanban board
+                  </Link>
+                </Button>
+              </div>
             </div>
           </header>
 
@@ -195,7 +208,7 @@ export default async function ProjectWorkspacePage({
               },
               {
                 label: "Workspace status",
-                value: "Placeholder",
+                value: "Kanban ready",
                 Icon: FolderKanban,
               },
             ].map((item) => (

--- a/src/app/(app)/projects/[projectId]/stories/[storyId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/stories/[storyId]/page.tsx
@@ -4,6 +4,7 @@ import {
   ArrowLeft,
   CheckSquare,
   ClipboardList,
+  Columns3,
   Flag,
   Gauge,
   MessageSquareText,
@@ -142,6 +143,14 @@ export default async function StoryDetailPage({
               </span>
             </div>
           </header>
+
+          <Link
+            href={`/projects/${typedProject.id}/kanban`}
+            className="inline-flex w-fit items-center gap-2 rounded-2xl bg-slate-950 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-slate-800"
+          >
+            <Columns3 className="size-4" />
+            Open Kanban board
+          </Link>
 
           <section className="grid gap-5 md:grid-cols-4">
             {[

--- a/src/components/kanban/kanban-board.tsx
+++ b/src/components/kanban/kanban-board.tsx
@@ -1,0 +1,19 @@
+import type { KanbanColumnModel } from "@/lib/kanban";
+
+import { KanbanColumn } from "./kanban-column";
+
+type KanbanBoardProps = {
+  columns: KanbanColumnModel[];
+};
+
+export function KanbanBoard({ columns }: KanbanBoardProps) {
+  return (
+    <div className="overflow-x-auto pb-3">
+      <div className="grid min-w-[1180px] grid-cols-5 gap-4">
+        {columns.map((column) => (
+          <KanbanColumn key={column.status} column={column} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/kanban/kanban-column.tsx
+++ b/src/components/kanban/kanban-column.tsx
@@ -1,0 +1,50 @@
+import type { KanbanColumnModel } from "@/lib/kanban";
+import { cn } from "@/lib/utils";
+
+import { KanbanStoryCard } from "./kanban-story-card";
+
+type KanbanColumnProps = {
+  column: KanbanColumnModel;
+};
+
+export function KanbanColumn({ column }: KanbanColumnProps) {
+  return (
+    <section className="rounded-[1.5rem] border border-slate-200 bg-slate-50/90 p-3">
+      <div className="flex items-start justify-between gap-3 px-1">
+        <div>
+          <div className="flex items-center gap-2">
+            <div className="inline-flex size-8 items-center justify-center rounded-xl bg-white text-slate-600">
+              <column.Icon className="size-4" />
+            </div>
+            <h2 className="font-heading text-lg font-semibold text-slate-950">
+              {column.label}
+            </h2>
+          </div>
+          <p className="mt-2 text-xs leading-5 text-slate-500">
+            {column.description}
+          </p>
+        </div>
+        <span
+          className={cn(
+            "rounded-full px-2.5 py-1 text-xs font-semibold",
+            column.accentClass,
+          )}
+        >
+          {column.stories.length}
+        </span>
+      </div>
+
+      <div className="mt-4 space-y-3">
+        {column.stories.length > 0 ? (
+          column.stories.map((story) => (
+            <KanbanStoryCard key={story.id} story={story} />
+          ))
+        ) : (
+          <div className="rounded-[1.25rem] border border-dashed border-slate-300 bg-white/72 px-4 py-8 text-center text-sm leading-6 text-slate-500">
+            {column.emptyState}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/kanban/kanban-story-card.tsx
+++ b/src/components/kanban/kanban-story-card.tsx
@@ -1,0 +1,69 @@
+import Link from "next/link";
+import { ArrowUpRight, CheckSquare, Flag, Gauge } from "lucide-react";
+
+import {
+  getKanbanStatusLabel,
+  type KanbanStory,
+} from "@/lib/kanban";
+import { cn } from "@/lib/utils";
+
+const priorityClasses: Record<string, string> = {
+  low: "bg-slate-100 text-slate-700",
+  medium: "bg-blue-100 text-blue-800",
+  high: "bg-orange-100 text-orange-800",
+  urgent: "bg-rose-100 text-rose-800",
+};
+
+type KanbanStoryCardProps = {
+  story: KanbanStory;
+};
+
+export function KanbanStoryCard({ story }: KanbanStoryCardProps) {
+  const acceptanceCriteriaCount = story.acceptance_criteria?.length ?? 0;
+
+  return (
+    <article className="rounded-[1.25rem] border border-white bg-white p-4 shadow-[0_18px_45px_-34px_rgba(15,23,42,0.75)]">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <span
+            className={cn(
+              "rounded-full px-2.5 py-1 text-xs font-semibold capitalize",
+              priorityClasses[story.priority] ?? "bg-slate-100 text-slate-700",
+            )}
+          >
+            {story.priority}
+          </span>
+          <h3 className="mt-3 line-clamp-3 font-medium leading-6 text-slate-950">
+            {story.title}
+          </h3>
+        </div>
+        <Link
+          href={`/projects/${story.project_id}/stories/${story.id}`}
+          className="inline-flex size-8 shrink-0 items-center justify-center rounded-xl bg-slate-100 text-slate-500 transition-colors hover:bg-brand-soft hover:text-brand"
+          aria-label={`View story: ${story.title}`}
+        >
+          <ArrowUpRight className="size-4" />
+        </Link>
+      </div>
+
+      <div className="mt-4 flex flex-wrap gap-2 text-xs font-medium text-slate-600">
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-2.5 py-1.5">
+          <Gauge className="size-3.5" />
+          {story.story_points ?? 0} pts
+        </span>
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-brand-soft px-2.5 py-1.5 text-brand">
+          <CheckSquare className="size-3.5" />
+          {acceptanceCriteriaCount} criteria
+        </span>
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-2.5 py-1.5">
+          <Flag className="size-3.5" />
+          {story.sprint_name ?? "No sprint"}
+        </span>
+      </div>
+
+      <div className="mt-3 rounded-2xl bg-slate-50 px-3 py-2 text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+        {getKanbanStatusLabel(story.status)}
+      </div>
+    </article>
+  );
+}

--- a/src/lib/dashboard.ts
+++ b/src/lib/dashboard.ts
@@ -378,7 +378,7 @@ export const dashboardFocusItems = [
   },
   {
     label: "Project CRUD foundation",
-    detail: "Projects, sprints, and stories can be created through Supabase RLS.",
+    detail: "Projects, sprints, stories, and read-only Kanban boards use Supabase RLS.",
     Icon: Gauge,
   },
   {

--- a/src/lib/kanban.ts
+++ b/src/lib/kanban.ts
@@ -1,0 +1,133 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  Archive,
+  CheckCircle2,
+  ClipboardList,
+  Eye,
+  ListTodo,
+} from "lucide-react";
+
+export const kanbanStatuses = [
+  "backlog",
+  "todo",
+  "in_progress",
+  "review",
+  "done",
+] as const;
+
+export type KanbanStatus = (typeof kanbanStatuses)[number];
+
+export type KanbanStory = {
+  id: string;
+  project_id: string;
+  sprint_id: string | null;
+  title: string;
+  acceptance_criteria: string[] | null;
+  story_points: number | null;
+  priority: string;
+  status: KanbanStatus;
+  sort_order: number | null;
+  created_at: string;
+  sprint_name: string | null;
+};
+
+export type KanbanColumnConfig = {
+  status: KanbanStatus;
+  label: string;
+  description: string;
+  emptyState: string;
+  accentClass: string;
+  Icon: LucideIcon;
+};
+
+export type KanbanColumnModel = KanbanColumnConfig & {
+  stories: KanbanStory[];
+};
+
+export const kanbanColumnConfig: KanbanColumnConfig[] = [
+  {
+    status: "backlog",
+    label: "Backlog",
+    description: "Ideas and candidate stories before sprint commitment.",
+    emptyState: "No backlog stories yet.",
+    accentClass: "bg-slate-200 text-slate-700",
+    Icon: Archive,
+  },
+  {
+    status: "todo",
+    label: "To Do",
+    description: "Committed work ready for pickup.",
+    emptyState: "No stories waiting in To Do.",
+    accentClass: "bg-blue-100 text-blue-800",
+    Icon: ListTodo,
+  },
+  {
+    status: "in_progress",
+    label: "In Progress",
+    description: "Stories actively being worked.",
+    emptyState: "Nothing is in progress.",
+    accentClass: "bg-cyan-100 text-cyan-900",
+    Icon: ClipboardList,
+  },
+  {
+    status: "review",
+    label: "Review",
+    description: "Stories ready for validation.",
+    emptyState: "No stories are in review.",
+    accentClass: "bg-amber-100 text-amber-900",
+    Icon: Eye,
+  },
+  {
+    status: "done",
+    label: "Done",
+    description: "Completed stories for the project.",
+    emptyState: "No completed stories yet.",
+    accentClass: "bg-emerald-100 text-emerald-800",
+    Icon: CheckCircle2,
+  },
+];
+
+export function getKanbanStatusLabel(status: string) {
+  return (
+    kanbanColumnConfig.find((column) => column.status === status)?.label ??
+    status.replaceAll("_", " ")
+  );
+}
+
+export function isKanbanStatus(status: string): status is KanbanStatus {
+  return kanbanStatuses.includes(status as KanbanStatus);
+}
+
+export function buildKanbanColumns(stories: KanbanStory[]): KanbanColumnModel[] {
+  return kanbanColumnConfig.map((column) => ({
+    ...column,
+    stories: stories
+      .filter((story) => story.status === column.status)
+      .sort((a, b) => {
+        const sortA = a.sort_order ?? 0;
+        const sortB = b.sort_order ?? 0;
+
+        if (sortA !== sortB) {
+          return sortA - sortB;
+        }
+
+        return a.created_at.localeCompare(b.created_at);
+      }),
+  }));
+}
+
+export function getStoryStatusSummary(stories: KanbanStory[]) {
+  const countByStatus = new Map<KanbanStatus, number>(
+    kanbanStatuses.map((status) => [status, 0]),
+  );
+
+  stories.forEach((story) => {
+    countByStatus.set(story.status, (countByStatus.get(story.status) ?? 0) + 1);
+  });
+
+  return kanbanColumnConfig.map((column) => ({
+    label: column.label,
+    status: column.status,
+    count: countByStatus.get(column.status) ?? 0,
+  }));
+}


### PR DESCRIPTION
## Summary

This PR implements a basic project-specific Kanban board for Minavolve.

## Changes

- Added `/projects/[projectId]/kanban` page
- Added reusable Kanban board component
- Added reusable Kanban column component
- Added reusable Kanban story card component
- Grouped user stories by workflow status
- Displayed Backlog, To Do, In Progress, Review, and Done columns
- Added story card metadata for priority, story points, sprint, and acceptance criteria count
- Added empty states for columns with no stories
- Added story detail links from the board
- Added New story navigation from the Kanban page
- Added Kanban navigation from the project workspace
- Updated README current status

## Testing

- Ran `npm run lint`
- Ran `npm run dev`
- Logged in with a test user
- Opened an existing project workspace
- Verified Kanban link appears
- Opened `/projects/[projectId]/kanban`
- Verified all 5 Kanban columns appear
- Verified stories appear under the correct status columns
- Verified empty columns show empty states
- Verified story cards show title, priority, story points, sprint name, and acceptance criteria count
- Verified story detail links work
- Verified logged-out users cannot access the Kanban route
- Verified `/`, `/login`, `/register`, `/dashboard`, `/projects`, project workspace, sprint routes, and story routes still work

Closes Issue #16 