### PR TITLE
feat(kanban): add drag and drop story movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Minavolve
 
-Minavolve is an Agile sprint board product concept with room for an AI assistant. This repository currently ships a polished landing page, Supabase email/password authentication, an authenticated dashboard layout, initial Supabase-backed project/sprint/user story creation and listing, and a basic read-only Kanban board that later issues can extend with drag-and-drop interactions and AI workflows.
+Minavolve is an Agile sprint board product concept with room for an AI assistant. This repository currently ships a polished landing page, Supabase email/password authentication, an authenticated dashboard layout, initial Supabase-backed project/sprint/user story creation and listing, and a drag-and-drop Kanban board that persists story status and order.
 
 ## What this issue includes
 
@@ -13,7 +13,7 @@ Minavolve is an Agile sprint board product concept with room for an AI assistant
 - Authenticated project listing, project creation, and a basic project workspace placeholder backed by Supabase RLS
 - Project-scoped sprint listing, sprint creation, and a basic sprint workspace placeholder backed by Supabase RLS
 - Project-scoped user story listing, story creation, optional sprint assignment, and a basic story workspace placeholder backed by Supabase RLS
-- Project-scoped read-only Kanban board grouped by user story status
+- Project-scoped drag-and-drop Kanban board grouped by user story status
 - Starter environment variable documentation in `.env.example`
 - Initial Supabase schema migration for projects, sprints, stories, risks, AI generations, activity, memberships, and profiles
 
@@ -22,7 +22,7 @@ Minavolve is an Agile sprint board product concept with room for an AI assistant
 - No project editing or deletion
 - No sprint editing or deletion
 - No user story editing or deletion
-- No drag-and-drop board behavior or Kanban status updates
+- No story editing, deletion, or assignee workflows from the Kanban board
 - No charts or risk register CRUD
 - No AI API routes or provider integration
 
@@ -103,9 +103,9 @@ Current dashboard content is intentionally static:
 
 - Summary cards for projects, active sprints, user stories, and open risks. Project, active sprint, and user story counts are read from Supabase when available.
 - Placeholder sections for recent projects, sprint planning, Kanban preview, risk register, delivery analytics, and AI assistant
-- A visual Kanban preview with Backlog, To Do, In Progress, Review, and Done columns. Project workspaces also include a read-only Kanban board backed by user stories.
+- A visual Kanban preview with Backlog, To Do, In Progress, Review, and Done columns. Project workspaces also include a drag-and-drop Kanban board backed by user stories.
 
-Drag-and-drop, Kanban movement, charts, risk CRUD, and AI provider calls remain out of scope for this issue.
+Charts, risk CRUD, and AI provider calls remain out of scope for this issue.
 
 ## Project setup status
 
@@ -153,15 +153,18 @@ If story creation or listing returns a missing `acceptance_criteria` or `story_p
 
 ## Kanban board status
 
-Issue #16 adds a basic project-specific Kanban board:
+Issue #18 adds drag-and-drop movement to the project-specific Kanban board:
 
 - `/projects/[projectId]/kanban` reads user stories from `public.user_stories` for the current project.
 - Stories are grouped into Backlog, To Do, In Progress, Review, and Done columns based on `status`.
 - Cards show title, priority, story points, status, sprint name when linked, and acceptance criteria count.
+- Dragging a card between columns updates `public.user_stories.status`.
+- The board persists target-column ordering through `public.user_stories.sort_order`.
+- The move server action verifies the authenticated user, project access, story ownership by `project_id`, and valid Kanban status values before updating Supabase.
 - Project workspaces link to the Kanban board, and story detail pages link back to the board.
 - Empty columns show clear empty states.
 
-The board is read-only. Drag-and-drop, sort persistence, and status updates remain out of scope for this issue.
+The board intentionally does not implement story editing, deletion, charts, risk workflows, or AI provider calls.
 
 The implementation assumes `public.user_stories.status` and `public.user_stories.sort_order` already exist, as defined in the initial schema, and also uses the Issue #14 story fields such as `acceptance_criteria` and `story_points` for card metadata.
 

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -167,7 +167,7 @@ export default async function DashboardPage() {
                 id="kanban-preview"
                 eyebrow="Board"
                 title="Kanban preview"
-                description="Project workspaces now include a read-only Kanban board grouped by story status. This dashboard preview remains static; drag-and-drop and status updates come later."
+                description="Project workspaces now include a drag-and-drop Kanban board that persists story status and order through Supabase. This dashboard preview remains static."
               >
                 <KanbanPreview />
               </DashboardSection>

--- a/src/app/(app)/projects/[projectId]/kanban/actions.ts
+++ b/src/app/(app)/projects/[projectId]/kanban/actions.ts
@@ -1,0 +1,172 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { isKanbanStatus, type KanbanStatus } from "@/lib/kanban";
+import { createClient } from "@/utils/supabase/server";
+
+type MoveKanbanStoryInput = {
+  projectId: string;
+  storyId: string;
+  status: KanbanStatus;
+  orderedStoryIds: string[];
+};
+
+export type MoveKanbanStoryResult = {
+  ok: boolean;
+  message: string;
+};
+
+type ExistingStory = {
+  id: string;
+  status: string;
+};
+
+function getMoveErrorMessage(message: string) {
+  const normalized = message.toLowerCase();
+
+  if (
+    normalized.includes("status") ||
+    normalized.includes("sort_order") ||
+    normalized.includes("schema cache") ||
+    normalized.includes("column")
+  ) {
+    return "The user_stories table is missing the Kanban status or sort_order fields. Confirm the Supabase schema before moving stories.";
+  }
+
+  if (normalized.includes("violates check constraint")) {
+    return "The selected Kanban status is not supported by the database schema.";
+  }
+
+  if (normalized.includes("row-level security")) {
+    return "Supabase blocked the Kanban update. Confirm you are still a project member and the story RLS policies are applied.";
+  }
+
+  return "Unable to update the Kanban board. Refresh and try again.";
+}
+
+function getUniqueStoryIds(storyIds: string[]) {
+  return Array.from(new Set(storyIds.filter(Boolean)));
+}
+
+export async function moveKanbanStory(
+  input: MoveKanbanStoryInput,
+): Promise<MoveKanbanStoryResult> {
+  if (
+    !input.projectId ||
+    !input.storyId ||
+    !isKanbanStatus(input.status) ||
+    !input.orderedStoryIds.includes(input.storyId)
+  ) {
+    return {
+      ok: false,
+      message: "Invalid Kanban move. Refresh the board and try again.",
+    };
+  }
+
+  const orderedStoryIds = getUniqueStoryIds(input.orderedStoryIds);
+
+  if (
+    orderedStoryIds.length !== input.orderedStoryIds.length ||
+    orderedStoryIds.length > 250
+  ) {
+    return {
+      ok: false,
+      message: "Invalid Kanban order. Refresh the board and try again.",
+    };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return {
+      ok: false,
+      message: "Your session has expired. Sign in again before moving stories.",
+    };
+  }
+
+  const { data: project, error: projectError } = await supabase
+    .from("projects")
+    .select("id")
+    .eq("id", input.projectId)
+    .maybeSingle();
+
+  if (projectError || !project) {
+    return {
+      ok: false,
+      message: "Project not found or you do not have access to this board.",
+    };
+  }
+
+  const { data: existingStories, error: storyLookupError } = await supabase
+    .from("user_stories")
+    .select("id,status")
+    .eq("project_id", input.projectId)
+    .in("id", orderedStoryIds);
+
+  if (storyLookupError) {
+    return {
+      ok: false,
+      message: getMoveErrorMessage(storyLookupError.message),
+    };
+  }
+
+  const storyRows = (existingStories ?? []) as ExistingStory[];
+  const storyIdsInProject = new Set(storyRows.map((story) => story.id));
+
+  if (orderedStoryIds.some((storyId) => !storyIdsInProject.has(storyId))) {
+    return {
+      ok: false,
+      message: "This board move includes a story outside the current project.",
+    };
+  }
+
+  const nonMovedStoryChangedStatus = storyRows.some(
+    (story) => story.id !== input.storyId && story.status !== input.status,
+  );
+
+  if (nonMovedStoryChangedStatus) {
+    return {
+      ok: false,
+      message: "Only the dragged story can move between Kanban columns.",
+    };
+  }
+
+  const updates = orderedStoryIds.map((storyId, index) =>
+    supabase
+      .from("user_stories")
+      .update({
+        status: input.status,
+        sort_order: index * 1000,
+      })
+      .eq("id", storyId)
+      .eq("project_id", input.projectId)
+      .select("id")
+      .maybeSingle(),
+  );
+
+  const results = await Promise.all(updates);
+  const failedResult = results.find((result) => result.error || !result.data);
+
+  if (failedResult?.error || failedResult) {
+    return {
+      ok: false,
+      message: getMoveErrorMessage(
+        failedResult.error?.message ?? "Kanban update failed.",
+      ),
+    };
+  }
+
+  revalidatePath("/dashboard");
+  revalidatePath(`/projects/${input.projectId}`);
+  revalidatePath(`/projects/${input.projectId}/kanban`);
+  revalidatePath(`/projects/${input.projectId}/stories/${input.storyId}`);
+
+  return {
+    ok: true,
+    message: "Story moved.",
+  };
+}

--- a/src/app/(app)/projects/[projectId]/kanban/page.tsx
+++ b/src/app/(app)/projects/[projectId]/kanban/page.tsx
@@ -7,7 +7,6 @@ import { AppSidebar } from "@/components/app/app-sidebar";
 import { KanbanBoard } from "@/components/kanban/kanban-board";
 import { Button } from "@/components/ui/button";
 import {
-  buildKanbanColumns,
   getStoryStatusSummary,
   isKanbanStatus,
   type KanbanStory,
@@ -134,7 +133,6 @@ export default async function ProjectKanbanPage({ params }: KanbanPageProps) {
         ];
       });
 
-  const columns = buildKanbanColumns(kanbanStories);
   const summary = getStoryStatusSummary(kanbanStories);
 
   return (
@@ -167,9 +165,9 @@ export default async function ProjectKanbanPage({ params }: KanbanPageProps) {
                     Kanban board
                   </h1>
                   <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
-                    A read-only board for {typedProject.name}. Stories are
-                    grouped by status; drag-and-drop and status updates are
-                    intentionally out of scope for this issue.
+                    An interactive board for {typedProject.name}. Drag story
+                    cards between columns to update status while preserving
+                    project-scoped Supabase RLS access.
                   </p>
                 </div>
               </div>
@@ -217,7 +215,10 @@ export default async function ProjectKanbanPage({ params }: KanbanPageProps) {
           ) : null}
 
           <section className="rounded-[2rem] border border-white/80 bg-white/88 p-4 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-5">
-            <KanbanBoard columns={columns} />
+            <KanbanBoard
+              projectId={typedProject.id}
+              initialStories={kanbanStories}
+            />
           </section>
         </div>
       </div>

--- a/src/app/(app)/projects/[projectId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/page.tsx
@@ -171,7 +171,7 @@ export default async function ProjectWorkspacePage({
                   </h1>
                   <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
                     {typedProject.description ??
-                      "No project description yet. Project editing, sprint setup, and board data will be implemented in later issues."}
+                      "No project description yet. Project editing and richer sprint setup will be implemented in later issues."}
                   </p>
                 </div>
               </div>
@@ -276,8 +276,8 @@ export default async function ProjectWorkspacePage({
                   </h3>
                   <p className="mx-auto mt-2 max-w-xl text-sm leading-6 text-slate-600">
                     Create the first sprint for this project. User stories,
-                    Kanban data, risks, charts, and AI support will connect to
-                    sprints in later issues.
+                    Kanban movement, risks, charts, and AI support can connect
+                    to sprint context as the workflow matures.
                   </p>
                   <Button
                     asChild
@@ -356,9 +356,8 @@ export default async function ProjectWorkspacePage({
                   No stories yet
                 </h3>
                 <p className="mx-auto mt-2 max-w-xl text-sm leading-6 text-slate-600">
-                  Create the first user story for this project. Kanban movement,
-                  drag-and-drop, risks, charts, and AI support will connect to
-                  stories in later issues.
+                  Create the first user story for this project. The Kanban board
+                  can move stories by status once cards exist.
                 </p>
                 <Button
                   asChild

--- a/src/app/(app)/projects/[projectId]/stories/[storyId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/stories/[storyId]/page.tsx
@@ -133,7 +133,7 @@ export default async function StoryDetailPage({
                   </h1>
                   <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
                     {typedStory.description ??
-                      "No story description yet. Kanban movement and story editing will be added in later issues."}
+                      "No story description yet. Use the Kanban board to move this story through the workflow."}
                   </p>
                 </div>
               </div>

--- a/src/components/kanban/kanban-board.tsx
+++ b/src/components/kanban/kanban-board.tsx
@@ -1,19 +1,383 @@
-import type { KanbanColumnModel } from "@/lib/kanban";
+"use client";
+
+import { useRef, useState, useTransition } from "react";
+import {
+  closestCorners,
+  type CollisionDetection,
+  DndContext,
+  KeyboardCode,
+  KeyboardSensor,
+  PointerSensor,
+  pointerWithin,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragOverEvent,
+  type DragStartEvent,
+  type UniqueIdentifier,
+} from "@dnd-kit/core";
+import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
+import { useRouter } from "next/navigation";
+
+import { moveKanbanStory } from "@/app/(app)/projects/[projectId]/kanban/actions";
+import {
+  buildKanbanColumns,
+  compareKanbanStories,
+  getKanbanStatusFromColumnId,
+  getKanbanStatusLabel,
+  type KanbanStatus,
+  type KanbanStory,
+} from "@/lib/kanban";
 
 import { KanbanColumn } from "./kanban-column";
 
 type KanbanBoardProps = {
-  columns: KanbanColumnModel[];
+  projectId: string;
+  initialStories: KanbanStory[];
 };
 
-export function KanbanBoard({ columns }: KanbanBoardProps) {
+type ReorderedBoard = {
+  stories: KanbanStory[];
+  targetStatus: KanbanStatus;
+  orderedStoryIds: string[];
+};
+
+function getStoryId(id: UniqueIdentifier) {
+  return String(id);
+}
+
+function getStoriesByStatus(stories: KanbanStory[], status: KanbanStatus) {
+  return stories
+    .filter((story) => story.status === status)
+    .sort(compareKanbanStories);
+}
+
+function getStoryIdsByStatus(stories: KanbanStory[], status: KanbanStatus) {
+  return getStoriesByStatus(stories, status).map((story) => story.id);
+}
+
+function getDropStatus(overId: string, stories: KanbanStory[]) {
+  const columnStatus = getKanbanStatusFromColumnId(overId);
+
+  if (columnStatus) {
+    return columnStatus;
+  }
+
+  return stories.find((story) => story.id === overId)?.status ?? null;
+}
+
+const kanbanCollisionDetection: CollisionDetection = (args) => {
+  const pointerCollisions = pointerWithin(args);
+  const collisions =
+    pointerCollisions.length > 0 ? pointerCollisions : closestCorners(args);
+  const storyCollisions = collisions.filter(({ id }) => {
+    return !getKanbanStatusFromColumnId(getStoryId(id));
+  });
+
+  return storyCollisions.length > 0 ? storyCollisions : collisions;
+};
+
+function getReorderedBoard(
+  stories: KanbanStory[],
+  storyId: string,
+  overId: string,
+): ReorderedBoard | null {
+  if (storyId === overId) {
+    return null;
+  }
+
+  const movingStory = stories.find((story) => story.id === storyId);
+  const targetStatus = getDropStatus(overId, stories);
+
+  if (!movingStory || !targetStatus) {
+    return null;
+  }
+
+  const sourceStatus = movingStory.status;
+  const sourceStories = getStoriesByStatus(stories, sourceStatus);
+  const targetStoriesWithoutMoving = getStoriesByStatus(
+    stories,
+    targetStatus,
+  ).filter((story) => story.id !== storyId);
+  const overStory = stories.find((story) => story.id === overId);
+  let targetIndex = targetStoriesWithoutMoving.length;
+
+  if (overStory?.status === targetStatus) {
+    const overTargetIndex = targetStoriesWithoutMoving.findIndex(
+      (story) => story.id === overStory.id,
+    );
+
+    targetIndex =
+      overTargetIndex >= 0 ? overTargetIndex : targetStoriesWithoutMoving.length;
+
+    if (sourceStatus === targetStatus) {
+      const sourceIndex = sourceStories.findIndex(
+        (story) => story.id === storyId,
+      );
+      const sourceOverIndex = sourceStories.findIndex(
+        (story) => story.id === overStory.id,
+      );
+
+      if (sourceIndex >= 0 && sourceOverIndex >= 0 && sourceIndex < sourceOverIndex) {
+        targetIndex += 1;
+      }
+    }
+  }
+
+  const boundedTargetIndex = Math.max(
+    0,
+    Math.min(targetIndex, targetStoriesWithoutMoving.length),
+  );
+  const reorderedTargetStories = [...targetStoriesWithoutMoving];
+
+  reorderedTargetStories.splice(boundedTargetIndex, 0, {
+    ...movingStory,
+    status: targetStatus,
+    sort_order: boundedTargetIndex * 1000,
+  });
+
+  const normalizedTargetStories = reorderedTargetStories.map((story, index) => ({
+    ...story,
+    status: targetStatus,
+    sort_order: index * 1000,
+  }));
+  const normalizedStoryById = new Map(
+    normalizedTargetStories.map((story) => [story.id, story]),
+  );
+  const nextStories = stories.map(
+    (story) => normalizedStoryById.get(story.id) ?? story,
+  );
+  const currentTargetOrder = getStoriesByStatus(stories, targetStatus).map(
+    (story) => story.id,
+  );
+  const nextTargetOrder = normalizedTargetStories.map((story) => story.id);
+  const orderDidChange =
+    currentTargetOrder.length !== nextTargetOrder.length ||
+    currentTargetOrder.some((currentStoryId, index) => {
+      return currentStoryId !== nextTargetOrder[index];
+    });
+
+  if (sourceStatus === targetStatus && !orderDidChange) {
+    return null;
+  }
+
+  return {
+    stories: nextStories,
+    targetStatus,
+    orderedStoryIds: nextTargetOrder,
+  };
+}
+
+function getPersistedMove(
+  initialStories: KanbanStory[],
+  finalStories: KanbanStory[],
+  storyId: string,
+): ReorderedBoard | null {
+  const initialStory = initialStories.find((story) => story.id === storyId);
+  const finalStory = finalStories.find((story) => story.id === storyId);
+
+  if (!initialStory || !finalStory) {
+    return null;
+  }
+
+  const targetStatus = finalStory.status;
+  const initialTargetOrder = getStoryIdsByStatus(initialStories, targetStatus);
+  const finalTargetOrder = getStoryIdsByStatus(finalStories, targetStatus);
+  const statusDidChange = initialStory.status !== finalStory.status;
+  const orderDidChange =
+    initialTargetOrder.length !== finalTargetOrder.length ||
+    initialTargetOrder.some((currentStoryId, index) => {
+      return currentStoryId !== finalTargetOrder[index];
+    });
+
+  if (!statusDidChange && !orderDidChange) {
+    return null;
+  }
+
+  return {
+    stories: finalStories,
+    targetStatus,
+    orderedStoryIds: finalTargetOrder,
+  };
+}
+
+export function KanbanBoard({ projectId, initialStories }: KanbanBoardProps) {
+  const router = useRouter();
+  const dragStartStoriesRef = useRef<KanbanStory[] | null>(null);
+  const [stories, setStories] = useState(initialStories);
+  const [activeStory, setActiveStory] = useState<KanbanStory | null>(null);
+  const [activeOverStatus, setActiveOverStatus] =
+    useState<KanbanStatus | null>(null);
+  const [pendingStoryId, setPendingStoryId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [announcement, setAnnouncement] = useState("");
+  const [isPending, startTransition] = useTransition();
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+      keyboardCodes: {
+        start: [KeyboardCode.Space],
+        cancel: [KeyboardCode.Esc],
+        end: [KeyboardCode.Space, KeyboardCode.Tab],
+      },
+    }),
+  );
+  const columns = buildKanbanColumns(stories);
+  const movementDisabled = isPending || Boolean(pendingStoryId);
+
+  function handleDragStart(event: DragStartEvent) {
+    const story = stories.find(
+      (candidate) => candidate.id === getStoryId(event.active.id),
+    );
+
+    dragStartStoriesRef.current = stories;
+    setActiveStory(story ?? null);
+    setActiveOverStatus(story?.status ?? null);
+    setError(null);
+  }
+
+  function handleDragOver(event: DragOverEvent) {
+    if (!event.over || movementDisabled) {
+      setActiveOverStatus(null);
+      return;
+    }
+
+    const storyId = getStoryId(event.active.id);
+    const overId = getStoryId(event.over.id);
+    const overStatus = getDropStatus(overId, stories);
+    const reorderedBoard = getReorderedBoard(stories, storyId, overId);
+
+    setActiveOverStatus(overStatus);
+
+    if (reorderedBoard) {
+      setStories(reorderedBoard.stories);
+    }
+  }
+
+  function handleDragEnd(event: DragEndEvent) {
+    setActiveStory(null);
+    setActiveOverStatus(null);
+
+    const storyId = getStoryId(event.active.id);
+    const overId = event.over ? getStoryId(event.over.id) : null;
+    const previousStories = dragStartStoriesRef.current ?? stories;
+
+    if (!event.over || movementDisabled) {
+      setStories(previousStories);
+      dragStartStoriesRef.current = null;
+      return;
+    }
+
+    const finalReorder = overId
+      ? getReorderedBoard(stories, storyId, overId)
+      : null;
+    const finalStories = finalReorder?.stories ?? stories;
+    const persistedMove = getPersistedMove(
+      previousStories,
+      finalStories,
+      storyId,
+    );
+
+    dragStartStoriesRef.current = null;
+
+    if (!persistedMove) {
+      setStories(finalStories);
+      return;
+    }
+
+    const movedStory = previousStories.find((story) => story.id === storyId);
+
+    setStories(persistedMove.stories);
+    setPendingStoryId(storyId);
+
+    startTransition(() => {
+      void (async () => {
+        const result = await moveKanbanStory({
+          projectId,
+          storyId,
+          status: persistedMove.targetStatus,
+          orderedStoryIds: persistedMove.orderedStoryIds,
+        });
+
+        if (!result.ok) {
+          setStories(previousStories);
+          setError(result.message);
+        } else {
+          setAnnouncement(
+            `${movedStory?.title ?? "Story"} moved to ${getKanbanStatusLabel(
+              persistedMove.targetStatus,
+            )}.`,
+          );
+          router.refresh();
+        }
+
+        setPendingStoryId(null);
+      })();
+    });
+  }
+
+  function handleDragCancel() {
+    setActiveStory(null);
+    setActiveOverStatus(null);
+    setStories(dragStartStoriesRef.current ?? stories);
+    dragStartStoriesRef.current = null;
+  }
+
   return (
-    <div className="overflow-x-auto pb-3">
-      <div className="grid min-w-[1180px] grid-cols-5 gap-4">
-        {columns.map((column) => (
-          <KanbanColumn key={column.status} column={column} />
-        ))}
+    <div>
+      <p className="sr-only" aria-live="polite">
+        {announcement}
+      </p>
+
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm leading-6 text-slate-600">
+          Click a story card to open it, or drag the card between columns to
+          update its workflow status.
+        </p>
+        {pendingStoryId ? (
+          <p className="rounded-full bg-blue-50 px-3 py-1.5 text-xs font-semibold text-blue-800">
+            Saving board movement...
+          </p>
+        ) : null}
       </div>
+
+      {error ? (
+        <div className="mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm leading-6 text-rose-800">
+          {error}
+        </div>
+      ) : null}
+
+      <DndContext
+        id={`kanban-board-${projectId}`}
+        sensors={sensors}
+        collisionDetection={kanbanCollisionDetection}
+        onDragStart={handleDragStart}
+        onDragOver={handleDragOver}
+        onDragEnd={handleDragEnd}
+        onDragCancel={handleDragCancel}
+      >
+        <div className="overflow-x-auto pb-3">
+          <div className="grid min-w-[1180px] grid-cols-5 gap-4">
+            {columns.map((column) => (
+              <KanbanColumn
+                key={column.status}
+                column={column}
+                disabled={movementDisabled}
+                isDropTarget={
+                  Boolean(activeStory) && activeOverStatus === column.status
+                }
+                pendingStoryId={pendingStoryId}
+              />
+            ))}
+          </div>
+        </div>
+
+      </DndContext>
     </div>
   );
 }

--- a/src/components/kanban/kanban-column.tsx
+++ b/src/components/kanban/kanban-column.tsx
@@ -1,15 +1,50 @@
-import type { KanbanColumnModel } from "@/lib/kanban";
+"use client";
+
+import { useDroppable } from "@dnd-kit/core";
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+
+import {
+  getKanbanColumnId,
+  type KanbanColumnModel,
+} from "@/lib/kanban";
 import { cn } from "@/lib/utils";
 
 import { KanbanStoryCard } from "./kanban-story-card";
 
 type KanbanColumnProps = {
   column: KanbanColumnModel;
+  disabled?: boolean;
+  isDropTarget?: boolean;
+  pendingStoryId?: string | null;
 };
 
-export function KanbanColumn({ column }: KanbanColumnProps) {
+export function KanbanColumn({
+  column,
+  disabled = false,
+  isDropTarget = false,
+  pendingStoryId = null,
+}: KanbanColumnProps) {
+  const columnId = getKanbanColumnId(column.status);
+  const { isOver, setNodeRef } = useDroppable({
+    id: columnId,
+    data: {
+      type: "column",
+      status: column.status,
+    },
+  });
+
   return (
-    <section className="rounded-[1.5rem] border border-slate-200 bg-slate-50/90 p-3">
+    <section
+      ref={setNodeRef}
+      className={cn(
+        "rounded-[1.5rem] border border-slate-200 bg-slate-50/90 p-3 transition-all duration-150",
+        (isOver || isDropTarget) &&
+          "border-brand/50 bg-brand-soft/70 shadow-[0_18px_50px_-38px_rgba(14,165,233,0.9)] ring-2 ring-brand/15",
+      )}
+    >
       <div className="flex items-start justify-between gap-3 px-1">
         <div>
           <div className="flex items-center gap-2">
@@ -34,17 +69,27 @@ export function KanbanColumn({ column }: KanbanColumnProps) {
         </span>
       </div>
 
-      <div className="mt-4 space-y-3">
-        {column.stories.length > 0 ? (
-          column.stories.map((story) => (
-            <KanbanStoryCard key={story.id} story={story} />
-          ))
-        ) : (
-          <div className="rounded-[1.25rem] border border-dashed border-slate-300 bg-white/72 px-4 py-8 text-center text-sm leading-6 text-slate-500">
-            {column.emptyState}
-          </div>
-        )}
-      </div>
+      <SortableContext
+        items={column.stories.map((story) => story.id)}
+        strategy={verticalListSortingStrategy}
+      >
+        <div className="mt-4 min-h-32 space-y-3">
+          {column.stories.length > 0 ? (
+            column.stories.map((story) => (
+              <KanbanStoryCard
+                key={story.id}
+                story={story}
+                disabled={disabled}
+                isPending={pendingStoryId === story.id}
+              />
+            ))
+          ) : (
+            <div className="rounded-[1.25rem] border border-dashed border-slate-300 bg-white/72 px-4 py-8 text-center text-sm leading-6 text-slate-500">
+              {column.emptyState}
+            </div>
+          )}
+        </div>
+      </SortableContext>
     </section>
   );
 }

--- a/src/components/kanban/kanban-story-card.tsx
+++ b/src/components/kanban/kanban-story-card.tsx
@@ -1,5 +1,19 @@
-import Link from "next/link";
-import { ArrowUpRight, CheckSquare, Flag, Gauge } from "lucide-react";
+"use client";
+
+import type { CSSProperties } from "react";
+import type {
+  DraggableSyntheticListeners,
+} from "@dnd-kit/core";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { useRouter } from "next/navigation";
+import {
+  ArrowUpRight,
+  CheckSquare,
+  Flag,
+  Gauge,
+  Loader2,
+} from "lucide-react";
 
 import {
   getKanbanStatusLabel,
@@ -16,34 +30,69 @@ const priorityClasses: Record<string, string> = {
 
 type KanbanStoryCardProps = {
   story: KanbanStory;
+  disabled?: boolean;
+  isPending?: boolean;
 };
 
-export function KanbanStoryCard({ story }: KanbanStoryCardProps) {
-  const acceptanceCriteriaCount = story.acceptance_criteria?.length ?? 0;
+type KanbanStoryCardContentProps = {
+  story: KanbanStory;
+  setNodeRef?: (node: HTMLElement | null) => void;
+  style?: CSSProperties;
+  listeners?: DraggableSyntheticListeners;
+  disabled?: boolean;
+  isDragging?: boolean;
+  isPending?: boolean;
+};
 
-  return (
-    <article className="rounded-[1.25rem] border border-white bg-white p-4 shadow-[0_18px_45px_-34px_rgba(15,23,42,0.75)]">
+function KanbanStoryCardContent({
+  story,
+  setNodeRef,
+  style,
+  listeners,
+  disabled = false,
+  isDragging = false,
+  isPending = false,
+}: KanbanStoryCardContentProps) {
+  const router = useRouter();
+  const acceptanceCriteriaCount = story.acceptance_criteria?.length ?? 0;
+  const href = `/projects/${story.project_id}/stories/${story.id}`;
+  const cardClasses = cn(
+    "block rounded-[1.25rem] border border-white bg-white p-4 text-left shadow-[0_18px_45px_-34px_rgba(15,23,42,0.75)] outline-none transition-[border-color,box-shadow,background-color,opacity] duration-100 focus-visible:ring-2 focus-visible:ring-brand/40",
+    disabled || isPending
+      ? "cursor-not-allowed"
+      : "cursor-grab hover:border-brand/20 hover:shadow-[0_24px_58px_-36px_rgba(15,23,42,0.82)] active:cursor-grabbing",
+    isDragging && "opacity-70 shadow-[0_28px_70px_-34px_rgba(15,23,42,0.9)]",
+    isPending && "ring-2 ring-blue-200",
+  );
+  const content = (
+    <>
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <span
-            className={cn(
-              "rounded-full px-2.5 py-1 text-xs font-semibold capitalize",
-              priorityClasses[story.priority] ?? "bg-slate-100 text-slate-700",
-            )}
-          >
-            {story.priority}
-          </span>
+          <div className="flex flex-wrap items-center gap-2">
+            {isPending ? (
+              <span className="inline-flex size-8 items-center justify-center rounded-xl bg-blue-50 text-blue-700">
+                <Loader2 className="size-4 animate-spin" />
+              </span>
+            ) : null}
+            <span
+              className={cn(
+                "rounded-full px-2.5 py-1 text-xs font-semibold capitalize",
+                priorityClasses[story.priority] ?? "bg-slate-100 text-slate-700",
+              )}
+            >
+              {story.priority}
+            </span>
+          </div>
           <h3 className="mt-3 line-clamp-3 font-medium leading-6 text-slate-950">
             {story.title}
           </h3>
         </div>
-        <Link
-          href={`/projects/${story.project_id}/stories/${story.id}`}
-          className="inline-flex size-8 shrink-0 items-center justify-center rounded-xl bg-slate-100 text-slate-500 transition-colors hover:bg-brand-soft hover:text-brand"
-          aria-label={`View story: ${story.title}`}
+        <span
+          className="inline-flex size-8 shrink-0 items-center justify-center rounded-xl bg-slate-100 text-slate-500 transition-colors group-hover:bg-brand-soft group-hover:text-brand"
+          aria-hidden="true"
         >
           <ArrowUpRight className="size-4" />
-        </Link>
+        </span>
       </div>
 
       <div className="mt-4 flex flex-wrap gap-2 text-xs font-medium text-slate-600">
@@ -64,6 +113,94 @@ export function KanbanStoryCard({ story }: KanbanStoryCardProps) {
       <div className="mt-3 rounded-2xl bg-slate-50 px-3 py-2 text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
         {getKanbanStatusLabel(story.status)}
       </div>
-    </article>
+    </>
+  );
+
+  const { onKeyDown: listenerKeyDown, ...dragListeners } = listeners ?? {};
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      role="link"
+      tabIndex={0}
+      aria-label={`Open story: ${story.title}`}
+      aria-describedby={`kanban-board-${story.project_id}`}
+      aria-disabled={disabled || isPending}
+      aria-roledescription="sortable story card"
+      className={cn("group", cardClasses)}
+      draggable={false}
+      {...dragListeners}
+      onClick={(event) => {
+        if (disabled || isPending || isDragging) {
+          event.preventDefault();
+          return;
+        }
+
+        router.push(href);
+      }}
+      onDragStart={(event) => {
+        event.preventDefault();
+      }}
+      onKeyDown={(event) => {
+        listenerKeyDown?.(event);
+
+        if (
+          event.defaultPrevented ||
+          disabled ||
+          isPending ||
+          event.key !== "Enter"
+        ) {
+          return;
+        }
+
+        event.preventDefault();
+        router.push(href);
+      }}
+    >
+      {content}
+    </div>
+  );
+}
+
+export function KanbanStoryCard({
+  story,
+  disabled = false,
+  isPending = false,
+}: KanbanStoryCardProps) {
+  const {
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id: story.id,
+    transition: {
+      duration: 90,
+      easing: "cubic-bezier(0.2, 0, 0, 1)",
+    },
+    data: {
+      type: "story",
+      story,
+    },
+    disabled,
+  });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    willChange: isDragging ? "transform" : undefined,
+  };
+
+  return (
+    <KanbanStoryCardContent
+      story={story}
+      setNodeRef={setNodeRef}
+      style={style}
+      listeners={listeners}
+      disabled={disabled}
+      isDragging={isDragging}
+      isPending={isPending}
+    />
   );
 }

--- a/src/lib/dashboard.ts
+++ b/src/lib/dashboard.ts
@@ -326,7 +326,7 @@ export const riskRegisterItems: RiskItem[] = [
     owner: "Auth",
   },
   {
-    label: "Kanban ordering depends on later drag-and-drop persistence.",
+    label: "Kanban ordering depends on RLS-backed story movement.",
     severity: "High",
     owner: "Board",
   },
@@ -378,7 +378,7 @@ export const dashboardFocusItems = [
   },
   {
     label: "Project CRUD foundation",
-    detail: "Projects, sprints, stories, and read-only Kanban boards use Supabase RLS.",
+    detail: "Projects, sprints, stories, and drag-and-drop Kanban boards use Supabase RLS.",
     Icon: Gauge,
   },
   {

--- a/src/lib/kanban.ts
+++ b/src/lib/kanban.ts
@@ -44,6 +44,8 @@ export type KanbanColumnModel = KanbanColumnConfig & {
   stories: KanbanStory[];
 };
 
+const kanbanColumnIdPrefix = "kanban-column:";
+
 export const kanbanColumnConfig: KanbanColumnConfig[] = [
   {
     status: "backlog",
@@ -98,21 +100,35 @@ export function isKanbanStatus(status: string): status is KanbanStatus {
   return kanbanStatuses.includes(status as KanbanStatus);
 }
 
+export function getKanbanColumnId(status: KanbanStatus) {
+  return `${kanbanColumnIdPrefix}${status}`;
+}
+
+export function getKanbanStatusFromColumnId(id: string) {
+  const rawStatus = id.startsWith(kanbanColumnIdPrefix)
+    ? id.slice(kanbanColumnIdPrefix.length)
+    : "";
+
+  return isKanbanStatus(rawStatus) ? rawStatus : null;
+}
+
+export function compareKanbanStories(a: KanbanStory, b: KanbanStory) {
+  const sortA = a.sort_order ?? 0;
+  const sortB = b.sort_order ?? 0;
+
+  if (sortA !== sortB) {
+    return sortA - sortB;
+  }
+
+  return a.created_at.localeCompare(b.created_at);
+}
+
 export function buildKanbanColumns(stories: KanbanStory[]): KanbanColumnModel[] {
   return kanbanColumnConfig.map((column) => ({
     ...column,
     stories: stories
       .filter((story) => story.status === column.status)
-      .sort((a, b) => {
-        const sortA = a.sort_order ?? 0;
-        const sortB = b.sort_order ?? 0;
-
-        if (sortA !== sortB) {
-          return sortA - sortB;
-        }
-
-        return a.created_at.localeCompare(b.created_at);
-      }),
+      .sort(compareKanbanStories),
   }));
 }
 


### PR DESCRIPTION
## Summary

This PR adds drag-and-drop movement to the Minavolve project Kanban board.

## Changes

- Added Kanban server action for updating story status
- Added drag-and-drop support to the project Kanban board
- Allowed stories to move between Backlog, To Do, In Progress, Review, and Done
- Updated Supabase `user_stories.status` after drop
- Preserved story card metadata during movement
- Kept story detail and New story links working
- Added project-scoped status update handling
- Preserved existing Kanban display and empty states
- Updated README current status

## Testing

- Ran `npm run lint`
- Ran `npm run dev`
- Logged in with a test user
- Opened an existing project Kanban board
- Verified all 5 columns appear
- Dragged a story from Backlog to To Do
- Verified card moved visually
- Verified Supabase `user_stories.status` updated
- Refreshed the page and verified moved story persisted in the new column
- Moved a story across multiple columns
- Verified story metadata still displays
- Verified story detail links still work
- Verified New story link still works
- Verified logged-out users cannot access the Kanban route
- Verified `/`, `/login`, `/register`, `/dashboard`, `/projects`, project workspace, sprint routes, and story routes still work

Closes #18 