### PR TITLE
feat(ai): add AI user story generator with Groq

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Minavolve
 
-Minavolve is an Agile sprint board product concept with room for an AI assistant. This repository currently ships a polished landing page, Supabase email/password authentication, an authenticated dashboard layout, initial Supabase-backed project/sprint/user story creation and listing, and a drag-and-drop Kanban board that persists story status and order.
+Minavolve is an Agile sprint board product concept with an AI-assisted backlog workflow. This repository currently ships a polished landing page, Supabase email/password authentication, an authenticated dashboard layout, initial Supabase-backed project/sprint/user story creation and listing, a drag-and-drop Kanban board that persists story status and order, and an AI user story generator for project workspaces.
 
 ## What this issue includes
 
@@ -14,6 +14,7 @@ Minavolve is an Agile sprint board product concept with room for an AI assistant
 - Project-scoped sprint listing, sprint creation, and a basic sprint workspace placeholder backed by Supabase RLS
 - Project-scoped user story listing, story creation, optional sprint assignment, and a basic story workspace placeholder backed by Supabase RLS
 - Project-scoped drag-and-drop Kanban board grouped by user story status
+- Project-scoped AI user story generator backed by a protected server API route
 - Starter environment variable documentation in `.env.example`
 - Initial Supabase schema migration for projects, sprints, stories, risks, AI generations, activity, memberships, and profiles
 
@@ -24,7 +25,7 @@ Minavolve is an Agile sprint board product concept with room for an AI assistant
 - No user story editing or deletion
 - No story editing, deletion, or assignee workflows from the Kanban board
 - No charts or risk register CRUD
-- No AI API routes or provider integration
+- No acceptance criteria-only generator, story auto-insert, charts, or risk AI workflows
 
 ## Tech stack
 
@@ -71,6 +72,7 @@ Minavolve is an Agile sprint board product concept with room for an AI assistant
    - `http://localhost:3000/projects/[projectId]/sprints/new`
    - `http://localhost:3000/projects/[projectId]/stories/new`
    - `http://localhost:3000/projects/[projectId]/kanban`
+   - `http://localhost:3000/projects/[projectId]/ai/story-generator`
 
 ## Linting
 
@@ -94,6 +96,7 @@ npm run lint
 - `/projects/[projectId]/stories/new`: protected user story creation form
 - `/projects/[projectId]/stories/[storyId]`: protected user story workspace placeholder
 - `/projects/[projectId]/kanban`: protected project-specific Kanban board grouped by story status
+- `/projects/[projectId]/ai/story-generator`: protected AI user story generator
 
 ## Dashboard status
 
@@ -105,7 +108,7 @@ Current dashboard content is intentionally static:
 - Placeholder sections for recent projects, sprint planning, Kanban preview, risk register, delivery analytics, and AI assistant
 - A visual Kanban preview with Backlog, To Do, In Progress, Review, and Done columns. Project workspaces also include a drag-and-drop Kanban board backed by user stories.
 
-Charts, risk CRUD, and AI provider calls remain out of scope for this issue.
+Charts, risk CRUD, and broader AI assistant workflows remain out of scope for this issue.
 
 ## Project setup status
 
@@ -164,9 +167,25 @@ Issue #18 adds drag-and-drop movement to the project-specific Kanban board:
 - Project workspaces link to the Kanban board, and story detail pages link back to the board.
 - Empty columns show clear empty states.
 
-The board intentionally does not implement story editing, deletion, charts, risk workflows, or AI provider calls.
+The board intentionally does not implement story editing, deletion, charts, or risk workflows.
 
 The implementation assumes `public.user_stories.status` and `public.user_stories.sort_order` already exist, as defined in the initial schema, and also uses the Issue #14 story fields such as `acceptance_criteria` and `story_points` for card metadata.
+
+## AI user story generator status
+
+Issue #20 adds a project-scoped AI story generator:
+
+- `/projects/[projectId]/ai/story-generator` is protected by the existing Supabase server-side user check.
+- The generator accepts a required feature idea plus optional target user/persona and business goal context.
+- Input is validated with Zod before the provider call.
+- Client components call Minavolve's protected `/api/ai/user-story` route; `OPENAI_API_KEY` is read only on the server.
+- The API route uses the OpenAI Responses API with structured JSON output for title, user story, description, suggested priority, suggested story points, and acceptance criteria.
+- Successful generations are logged to `public.ai_generations` for the selected project when the cloud schema supports `generation_type = 'user_story'`.
+- Generated output is copy-ready and links back to the manual story creation form.
+
+The generator intentionally does not insert user stories automatically, edit existing stories, generate acceptance criteria independently, or add broader assistant workflows.
+
+If generation logging returns an `ai_generations_type_check` or missing column message, confirm the Supabase cloud `public.ai_generations` table supports the Issue #20 logging shape before retesting. This issue does not add or modify migration files.
 
 ## Environment variables
 
@@ -176,10 +195,12 @@ Copy `.env.example` to `.env.local` and provide the Supabase cloud project value
 - `NEXT_PUBLIC_SUPABASE_URL`
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
 
-AI provider variables remain placeholders for later issues:
+AI provider variables:
 
 - `OPENAI_API_KEY`
-- `ANTHROPIC_API_KEY`
+- `OPENAI_MODEL` (optional, defaults to `gpt-4.1-mini`)
+
+Do not prefix `OPENAI_API_KEY` with `NEXT_PUBLIC_`. It must remain server-only and should be configured in local `.env.local` and deployment environment variables.
 
 ## Supabase Auth setup
 

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -234,7 +234,7 @@ export default async function DashboardPage() {
                 id="ai-assistant"
                 eyebrow="Assistant"
                 title="AI assistant"
-                description="The UI reserves space for AI workflows without creating API routes or provider calls."
+                description="Project workspaces now include an AI user story generator that calls OpenAI from a protected server route and logs successful generations."
                 dark
               >
                 <div className="space-y-3">

--- a/src/app/(app)/projects/[projectId]/ai/story-generator/actions.ts
+++ b/src/app/(app)/projects/[projectId]/ai/story-generator/actions.ts
@@ -1,0 +1,35 @@
+"use server";
+
+import { notFound, redirect } from "next/navigation";
+
+import { createClient } from "@/utils/supabase/server";
+
+export type StoryGeneratorProject = {
+  id: string;
+  name: string;
+  project_key: string;
+  description: string | null;
+};
+
+export async function getStoryGeneratorProject(projectId: string) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { data: project, error } = await supabase
+    .from("projects")
+    .select("id,name,project_key,description")
+    .eq("id", projectId)
+    .maybeSingle();
+
+  if (error || !project) {
+    notFound();
+  }
+
+  return project as StoryGeneratorProject;
+}

--- a/src/app/(app)/projects/[projectId]/ai/story-generator/page.tsx
+++ b/src/app/(app)/projects/[projectId]/ai/story-generator/page.tsx
@@ -1,0 +1,83 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft, Bot, Sparkles } from "lucide-react";
+
+import { getStoryGeneratorProject } from "@/app/(app)/projects/[projectId]/ai/story-generator/actions";
+import { AppSidebar } from "@/components/app/app-sidebar";
+import { UserStoryGeneratorForm } from "@/components/ai/user-story-generator-form";
+import { Button } from "@/components/ui/button";
+
+export const metadata: Metadata = {
+  title: "AI user story generator",
+  description: "Generate structured Agile user stories for a Minavolve project.",
+};
+
+type StoryGeneratorPageProps = {
+  params: Promise<{
+    projectId: string;
+  }>;
+};
+
+export default async function StoryGeneratorPage({
+  params,
+}: StoryGeneratorPageProps) {
+  const { projectId } = await params;
+  const project = await getStoryGeneratorProject(projectId);
+
+  return (
+    <main className="min-h-screen px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto flex w-full max-w-[1540px] flex-col gap-6 lg:flex-row">
+        <div className="lg:w-72 lg:shrink-0">
+          <AppSidebar activeHref="/projects" />
+        </div>
+
+        <div className="min-w-0 flex-1 space-y-6">
+          <Link
+            href={`/projects/${project.id}`}
+            className="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition-colors hover:text-slate-950"
+          >
+            <ArrowLeft className="size-4" />
+            Back to project
+          </Link>
+
+          <header className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6">
+            <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
+              <div className="flex items-start gap-4">
+                <div className="inline-flex size-12 items-center justify-center rounded-2xl bg-slate-950 text-white">
+                  <Bot className="size-6" />
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-brand">
+                    {project.project_key} AI workflow
+                  </p>
+                  <h1 className="mt-2 font-heading text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                    AI user story generator
+                  </h1>
+                  <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
+                    Turn a feature idea into a structured Agile user story for{" "}
+                    {project.name}. The result is copy-ready for manual story
+                    creation and logged to this project&apos;s AI generation
+                    history.
+                  </p>
+                </div>
+              </div>
+
+              <Button
+                asChild
+                size="lg"
+                className="h-10 rounded-2xl bg-slate-950 px-4 text-white hover:bg-slate-800"
+              >
+                <Link href={`/projects/${project.id}/stories/new`}>
+                  <Sparkles className="size-4" />
+                  Manual story form
+                </Link>
+              </Button>
+            </div>
+          </header>
+
+          <UserStoryGeneratorForm projectId={project.id} />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(app)/projects/[projectId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/page.tsx
@@ -10,6 +10,7 @@ import {
   MessageSquareText,
   Plus,
   ShieldAlert,
+  Sparkles,
   TimerReset,
 } from "lucide-react";
 import { notFound, redirect } from "next/navigation";
@@ -183,6 +184,18 @@ export default async function ProjectWorkspacePage({
                 <Button
                   asChild
                   size="lg"
+                  className="h-10 rounded-2xl border border-cyan-200 bg-cyan-50 px-4 text-cyan-950 hover:bg-cyan-100"
+                >
+                  <Link
+                    href={`/projects/${typedProject.id}/ai/story-generator`}
+                  >
+                    <Sparkles className="size-4" />
+                    AI story generator
+                  </Link>
+                </Button>
+                <Button
+                  asChild
+                  size="lg"
                   className="h-10 rounded-2xl bg-slate-950 px-4 text-white hover:bg-slate-800"
                 >
                   <Link href={`/projects/${typedProject.id}/kanban`}>
@@ -322,19 +335,34 @@ export default async function ProjectWorkspacePage({
                 </h2>
                 <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
                   Stories are scoped to this project and can optionally be
-                  assigned to one of the project sprints.
+                  assigned to one of the project sprints. Use the AI generator
+                  to draft copy-ready story fields from a feature idea.
                 </p>
               </div>
-              <Button
-                asChild
-                size="lg"
-                className="h-10 rounded-2xl bg-slate-950 px-4 text-white hover:bg-slate-800"
-              >
-                <Link href={`/projects/${typedProject.id}/stories/new`}>
-                  <MessageSquarePlus className="size-4" />
-                  New story
-                </Link>
-              </Button>
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <Button
+                  asChild
+                  size="lg"
+                  className="h-10 rounded-2xl border border-cyan-200 bg-cyan-50 px-4 text-cyan-950 hover:bg-cyan-100"
+                >
+                  <Link
+                    href={`/projects/${typedProject.id}/ai/story-generator`}
+                  >
+                    <Sparkles className="size-4" />
+                    Generate story
+                  </Link>
+                </Button>
+                <Button
+                  asChild
+                  size="lg"
+                  className="h-10 rounded-2xl bg-slate-950 px-4 text-white hover:bg-slate-800"
+                >
+                  <Link href={`/projects/${typedProject.id}/stories/new`}>
+                    <MessageSquarePlus className="size-4" />
+                    New story
+                  </Link>
+                </Button>
+              </div>
             </div>
 
             {storiesError ? (
@@ -356,19 +384,34 @@ export default async function ProjectWorkspacePage({
                   No stories yet
                 </h3>
                 <p className="mx-auto mt-2 max-w-xl text-sm leading-6 text-slate-600">
-                  Create the first user story for this project. The Kanban board
+                  Create the first user story for this project, or use the AI
+                  generator to draft one from a feature idea. The Kanban board
                   can move stories by status once cards exist.
                 </p>
-                <Button
-                  asChild
-                  size="lg"
-                  className="mt-6 h-11 rounded-2xl bg-slate-950 px-5 text-white hover:bg-slate-800"
-                >
-                  <Link href={`/projects/${typedProject.id}/stories/new`}>
-                    <MessageSquarePlus className="size-4" />
-                    Create first story
-                  </Link>
-                </Button>
+                <div className="mt-6 flex flex-col justify-center gap-3 sm:flex-row">
+                  <Button
+                    asChild
+                    size="lg"
+                    className="h-11 rounded-2xl border border-cyan-200 bg-cyan-50 px-5 text-cyan-950 hover:bg-cyan-100"
+                  >
+                    <Link
+                      href={`/projects/${typedProject.id}/ai/story-generator`}
+                    >
+                      <Sparkles className="size-4" />
+                      Generate first story
+                    </Link>
+                  </Button>
+                  <Button
+                    asChild
+                    size="lg"
+                    className="h-11 rounded-2xl bg-slate-950 px-5 text-white hover:bg-slate-800"
+                  >
+                    <Link href={`/projects/${typedProject.id}/stories/new`}>
+                      <MessageSquarePlus className="size-4" />
+                      Create first story
+                    </Link>
+                  </Button>
+                </div>
               </div>
             )}
           </section>

--- a/src/app/(app)/projects/[projectId]/stories/new/page.tsx
+++ b/src/app/(app)/projects/[projectId]/stories/new/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowLeft, MessageSquarePlus } from "lucide-react";
+import { ArrowLeft, MessageSquarePlus, Sparkles } from "lucide-react";
 import { notFound, redirect } from "next/navigation";
 
 import { AppSidebar } from "@/components/app/app-sidebar";
@@ -8,6 +8,7 @@ import {
   StoryForm,
   type StorySprintOption,
 } from "@/components/stories/story-form";
+import { Button } from "@/components/ui/button";
 import { createClient } from "@/utils/supabase/server";
 
 export const metadata: Metadata = {
@@ -113,6 +114,30 @@ export default async function NewStoryPage({
               backlog story without selecting a sprint.
             </div>
           ) : null}
+
+          <section className="flex flex-col gap-4 rounded-[2rem] border border-cyan-200/80 bg-cyan-50/80 p-5 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-cyan-800">
+                AI draft available
+              </p>
+              <p className="mt-2 text-sm leading-6 text-cyan-950">
+                Need a starting point? Generate a copy-ready story draft, then
+                paste the fields into this manual form.
+              </p>
+            </div>
+            <Button
+              asChild
+              size="lg"
+              className="h-10 rounded-2xl bg-slate-950 px-4 text-white hover:bg-slate-800"
+            >
+              <Link
+                href={`/projects/${typedProject.id}/ai/story-generator`}
+              >
+                <Sparkles className="size-4" />
+                Generate with AI
+              </Link>
+            </Button>
+          </section>
 
           <StoryForm
             projectId={typedProject.id}

--- a/src/app/api/ai/user-story/route.ts
+++ b/src/app/api/ai/user-story/route.ts
@@ -1,0 +1,248 @@
+import { NextResponse } from "next/server";
+
+import {
+  buildUserStoryPrompt,
+  userStoryGeneratorInstructions,
+} from "@/lib/ai/prompts";
+import { type GeneratedUserStory } from "@/lib/ai/types";
+import {
+  aiStoryGeneratorSchema,
+  generatedUserStorySchema,
+} from "@/lib/validators/ai-story";
+import { createClient } from "@/utils/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+type GroqResponseBody = {
+  error?: { message?: string } | null;
+  model?: string;
+  choices?: Array<{
+    message?: { content?: string };
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+  };
+};
+
+function jsonError(message: string, status = 400) {
+  return NextResponse.json({ error: message }, { status });
+}
+
+function getProviderErrorMessage(status: number, message?: string) {
+  if (status === 401) {
+    return "Groq rejected the API key. Check GROQ_API_KEY in the server environment.";
+  }
+
+  if (status === 429) {
+    return "Groq rate limits were reached. Wait briefly and try again.";
+  }
+
+  if (message) {
+    return `Groq could not generate the story: ${message}`;
+  }
+
+  return "Groq could not generate the story right now. Try again shortly.";
+}
+
+function getGenerationLogError(message: string) {
+  const normalized = message.toLowerCase();
+
+  if (
+    normalized.includes("generation_type") ||
+    normalized.includes("violates check constraint")
+  ) {
+    return "The ai_generations table does not currently allow generation_type = 'user_story'. Update the Supabase cloud schema before retesting AI generation logging.";
+  }
+
+  if (
+    normalized.includes("user_id") ||
+    normalized.includes("output") ||
+    normalized.includes("requested_by") ||
+    normalized.includes("response") ||
+    normalized.includes("schema cache") ||
+    normalized.includes("column")
+  ) {
+    return "The ai_generations table columns do not match the Issue #20 logging shape. Confirm the cloud schema before retesting AI generation logging.";
+  }
+
+  if (normalized.includes("row-level security")) {
+    return "Supabase blocked the generation log. Confirm you are still a project member and the AI generation RLS policies are applied.";
+  }
+
+  return "The story was generated, but Minavolve could not save the generation log.";
+}
+
+async function logGeneration({
+  generatedStory,
+  inputTokens,
+  model,
+  outputTokens,
+  projectId,
+  prompt,
+  supabase,
+  userId,
+}: {
+  generatedStory: GeneratedUserStory;
+  inputTokens?: number;
+  model: string;
+  outputTokens?: number;
+  projectId: string;
+  prompt: string;
+  supabase: Awaited<ReturnType<typeof createClient>>;
+  userId: string;
+}) {
+  const { error } = await supabase.from("ai_generations").insert({
+    project_id: projectId,
+    requested_by: userId,
+    generation_type: "user_story",
+    prompt,
+    response: JSON.stringify(generatedStory),
+    provider: "groq",
+    model,
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    status: "completed",
+  });
+
+  if (error) {
+    throw new Error(getGenerationLogError(error.message));
+  }
+}
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return jsonError("Sign in before generating user stories.", 401);
+  }
+
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError("Send valid JSON to generate a user story.");
+  }
+
+  const parsed = aiStoryGeneratorSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return jsonError(
+      parsed.error.issues[0]?.message ?? "Enter valid generator details.",
+    );
+  }
+
+  const { data: project, error: projectError } = await supabase
+    .from("projects")
+    .select("id,name,project_key")
+    .eq("id", parsed.data.projectId)
+    .maybeSingle();
+
+  if (projectError || !project) {
+    return jsonError(
+      "Project not found or you do not have access to generate stories for it.",
+      404,
+    );
+  }
+
+  const apiKey = process.env.GROQ_API_KEY?.trim();
+
+  if (!apiKey) {
+    return jsonError(
+      "GROQ_API_KEY is missing. Add it to .env.local and restart the dev server.",
+      503,
+    );
+  }
+
+  const model = process.env.GROQ_MODEL ?? "llama-3.3-70b-versatile";
+  const prompt = buildUserStoryPrompt(parsed.data);
+
+  const providerResponse = await fetch(
+    "https://api.groq.com/openai/v1/chat/completions",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        temperature: 0.7,
+        response_format: { type: "json_object" },
+        messages: [
+          { role: "system", content: userStoryGeneratorInstructions },
+          { role: "user", content: prompt },
+        ],
+      }),
+    },
+  );
+
+  const providerJson = (await providerResponse
+    .json()
+    .catch(() => null)) as GroqResponseBody | null;
+
+  if (!providerResponse.ok || !providerJson) {
+    return jsonError(
+      getProviderErrorMessage(
+        providerResponse.status,
+        providerJson?.error?.message,
+      ),
+      providerResponse.status || 502,
+    );
+  }
+
+  const rawText = providerJson.choices?.[0]?.message?.content ?? "";
+
+  if (!rawText) {
+    return jsonError(
+      "Groq returned an empty response. Try generating the story again.",
+      502,
+    );
+  }
+
+  let rawStory: unknown;
+
+  try {
+    rawStory = JSON.parse(rawText);
+  } catch {
+    return jsonError(
+      "Groq returned a response Minavolve could not parse as JSON.",
+      502,
+    );
+  }
+
+  const generated = generatedUserStorySchema.safeParse(rawStory);
+
+  if (!generated.success) {
+    return jsonError(
+      "Groq returned a story that did not match the expected structure. Try again.",
+      502,
+    );
+  }
+
+  try {
+    await logGeneration({
+      generatedStory: generated.data,
+      inputTokens: providerJson.usage?.prompt_tokens,
+      model: providerJson.model ?? model,
+      outputTokens: providerJson.usage?.completion_tokens,
+      projectId: parsed.data.projectId,
+      prompt,
+      supabase,
+      userId: user.id,
+    });
+  } catch (error) {
+    return jsonError(
+      error instanceof Error
+        ? error.message
+        : "The story was generated, but Minavolve could not save the generation log.",
+      500,
+    );
+  }
+
+  return NextResponse.json({ story: generated.data });
+}

--- a/src/components/ai/generated-story-card.tsx
+++ b/src/components/ai/generated-story-card.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Check, Clipboard, ExternalLink, ListChecks, Sparkles } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import type { GeneratedUserStory } from "@/lib/ai/types";
+
+type GeneratedStoryCardProps = {
+  projectId: string;
+  story: GeneratedUserStory;
+};
+
+function getCopyText(story: GeneratedUserStory) {
+  return [
+    `Title: ${story.title}`,
+    "",
+    story.user_story,
+    "",
+    `Description: ${story.description}`,
+    "",
+    `Priority: ${story.suggested_priority}`,
+    `Story points: ${story.suggested_story_points}`,
+    "",
+    "Acceptance criteria:",
+    ...story.acceptance_criteria.map((criterion) => `- ${criterion}`),
+  ].join("\n");
+}
+
+export function GeneratedStoryCard({
+  projectId,
+  story,
+}: GeneratedStoryCardProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function copyStory() {
+    await navigator.clipboard.writeText(getCopyText(story));
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1800);
+  }
+
+  return (
+    <article className="rounded-[2rem] border border-cyan-200/80 bg-cyan-50/80 p-5 shadow-[0_25px_80px_-55px_rgba(14,116,144,0.8)] sm:p-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-cyan-800">
+            <Sparkles className="size-4" />
+            Generated story
+          </p>
+          <h2 className="mt-3 font-heading text-2xl font-semibold text-slate-950">
+            {story.title}
+          </h2>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <span className="rounded-full bg-white px-3 py-1.5 text-xs font-semibold capitalize text-cyan-900">
+            {story.suggested_priority}
+          </span>
+          <span className="rounded-full bg-white px-3 py-1.5 text-xs font-semibold text-cyan-900">
+            {story.suggested_story_points} pts
+          </span>
+        </div>
+      </div>
+
+      <div className="mt-5 grid gap-4">
+        <section className="rounded-[1.5rem] bg-white/82 p-4">
+          <h3 className="text-sm font-semibold text-slate-800">User story</h3>
+          <p className="mt-2 text-sm leading-6 text-slate-700">
+            {story.user_story}
+          </p>
+        </section>
+
+        <section className="rounded-[1.5rem] bg-white/82 p-4">
+          <h3 className="text-sm font-semibold text-slate-800">Description</h3>
+          <p className="mt-2 text-sm leading-6 text-slate-700">
+            {story.description}
+          </p>
+        </section>
+
+        <section className="rounded-[1.5rem] bg-white/82 p-4">
+          <h3 className="inline-flex items-center gap-2 text-sm font-semibold text-slate-800">
+            <ListChecks className="size-4" />
+            Acceptance criteria
+          </h3>
+          <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-700">
+            {story.acceptance_criteria.map((criterion) => (
+              <li key={criterion} className="flex gap-2">
+                <Check className="mt-1 size-4 shrink-0 text-cyan-700" />
+                <span>{criterion}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+
+      <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm leading-6 text-cyan-900">
+          Copy these fields into the manual story form. Direct story insertion
+          remains out of scope for this issue.
+        </p>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <Button
+            type="button"
+            variant="outline"
+            size="lg"
+            onClick={copyStory}
+            className="h-11 rounded-2xl border-cyan-200 bg-white px-5 text-cyan-950 hover:bg-cyan-50"
+          >
+            {copied ? <Check className="size-4" /> : <Clipboard className="size-4" />}
+            {copied ? "Copied" : "Copy story"}
+          </Button>
+          <Button
+            asChild
+            size="lg"
+            className="h-11 rounded-2xl bg-slate-950 px-5 text-white hover:bg-slate-800"
+          >
+            <Link href={`/projects/${projectId}/stories/new`}>
+              <ExternalLink className="size-4" />
+              Open new story form
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/components/ai/user-story-generator-form.tsx
+++ b/src/components/ai/user-story-generator-form.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import { Loader2, Sparkles } from "lucide-react";
+
+import { GeneratedStoryCard } from "@/components/ai/generated-story-card";
+import { Button } from "@/components/ui/button";
+import type { GeneratedUserStory } from "@/lib/ai/types";
+import { aiStoryGeneratorSchema } from "@/lib/validators/ai-story";
+
+type UserStoryGeneratorFormProps = {
+  projectId: string;
+};
+
+type AiStoryApiResponse = {
+  story?: GeneratedUserStory;
+  error?: string;
+};
+
+export function UserStoryGeneratorForm({
+  projectId,
+}: UserStoryGeneratorFormProps) {
+  const [featureIdea, setFeatureIdea] = useState("");
+  const [targetUser, setTargetUser] = useState("");
+  const [businessGoal, setBusinessGoal] = useState("");
+  const [generatedStory, setGeneratedStory] =
+    useState<GeneratedUserStory | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setGeneratedStory(null);
+
+    const payload = {
+      projectId,
+      featureIdea,
+      targetUser,
+      businessGoal,
+    };
+    const parsed = aiStoryGeneratorSchema.safeParse(payload);
+
+    if (!parsed.success) {
+      setError(
+        parsed.error.issues[0]?.message ?? "Enter valid generator details.",
+      );
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const response = await fetch("/api/ai/user-story", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(parsed.data),
+      });
+      const data = (await response.json()) as AiStoryApiResponse;
+
+      if (!response.ok || !data.story) {
+        setError(data.error ?? "Unable to generate a user story right now.");
+        return;
+      }
+
+      setGeneratedStory(data.story);
+    } catch {
+      setError("Network error while generating the story. Try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <div className="grid gap-6 xl:grid-cols-[minmax(0,0.9fr)_minmax(420px,1.1fr)]">
+      <form
+        onSubmit={handleSubmit}
+        className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6"
+      >
+        {error ? (
+          <div className="mb-6 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm leading-6 text-rose-800">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="grid gap-5">
+          <label className="block text-sm font-semibold text-slate-800">
+            Feature idea
+            <textarea
+              required
+              minLength={10}
+              maxLength={800}
+              rows={6}
+              value={featureIdea}
+              onChange={(event) => setFeatureIdea(event.target.value)}
+              placeholder="Example: Let project owners invite teammates and assign roles from the workspace."
+              className="mt-2 w-full resize-y rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm leading-6 text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+            />
+            <span className="mt-2 block text-xs font-normal leading-5 text-slate-500">
+              Required. Use 10 to 800 characters.
+            </span>
+          </label>
+
+          <label className="block text-sm font-semibold text-slate-800">
+            Target user/persona
+            <input
+              maxLength={200}
+              value={targetUser}
+              onChange={(event) => setTargetUser(event.target.value)}
+              placeholder="Example: Scrum master, product owner, developer"
+              className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+            />
+          </label>
+
+          <label className="block text-sm font-semibold text-slate-800">
+            Business goal or context
+            <textarea
+              maxLength={800}
+              rows={5}
+              value={businessGoal}
+              onChange={(event) => setBusinessGoal(event.target.value)}
+              placeholder="Example: Reduce sprint planning admin time and make ownership clearer."
+              className="mt-2 w-full resize-y rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm leading-6 text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+            />
+          </label>
+        </div>
+
+        <div className="mt-7 flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-sm leading-6 text-slate-500">
+            Generated drafts are logged to Supabase for the current project.
+          </p>
+          <Button
+            type="submit"
+            size="lg"
+            disabled={isLoading}
+            className="h-11 rounded-2xl bg-slate-950 px-5 text-white hover:bg-slate-800"
+          >
+            {isLoading ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <Sparkles className="size-4" />
+            )}
+            {isLoading ? "Generating..." : "Generate story"}
+          </Button>
+        </div>
+      </form>
+
+      {generatedStory ? (
+        <GeneratedStoryCard projectId={projectId} story={generatedStory} />
+      ) : (
+        <aside className="rounded-[2rem] border border-white/80 bg-slate-950 p-6 text-white shadow-[0_25px_80px_-55px_rgba(15,23,42,0.9)]">
+          <div className="inline-flex size-12 items-center justify-center rounded-2xl bg-white/10 text-cyan-200">
+            <Sparkles className="size-6" />
+          </div>
+          <h2 className="mt-5 font-heading text-2xl font-semibold">
+            What Minavolve generates
+          </h2>
+          <p className="mt-3 text-sm leading-6 text-slate-300">
+            The assistant returns a structured story with title, user story,
+            implementation description, priority, story points, and testable
+            acceptance criteria.
+          </p>
+          <div className="mt-5 rounded-2xl border border-white/10 bg-white/[0.06] p-4 text-sm leading-6 text-slate-300">
+            The OpenAI API key is read only from server environment variables.
+            Client components call Minavolve&apos;s protected API route instead
+            of the provider directly.
+          </div>
+        </aside>
+      )}
+    </div>
+  );
+}

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -1,0 +1,33 @@
+import type { AiStoryGeneratorInput } from "@/lib/ai/types";
+
+export const userStoryGeneratorInstructions = [
+  "You are Minavolve's Agile product assistant.",
+  "Generate one high-quality user story for a project team.",
+  "Keep the story implementation-ready, testable, and scoped for a sprint.",
+  "Do not mention that you are an AI assistant.",
+  "Return ONLY the raw JSON object — no markdown, no code fences, no explanation, no wrapper key.",
+].join(" ");
+
+export function buildUserStoryPrompt(input: AiStoryGeneratorInput) {
+  const targetUser = input.targetUser?.trim() || "Not specified";
+  const businessGoal = input.businessGoal?.trim() || "Not specified";
+
+  return [
+    "Create one Agile user story from this product input.",
+    "",
+    `Feature idea: ${input.featureIdea.trim()}`,
+    `Target user/persona: ${targetUser}`,
+    `Business goal/context: ${businessGoal}`,
+    "",
+    "Return ONLY a flat JSON object with exactly these six keys — no wrapper, no extra fields:",
+    '{"title":"...","user_story":"As a [user], I want [capability], so that [benefit].","description":"...","suggested_priority":"medium","suggested_story_points":5,"acceptance_criteria":["...","...","..."]}',
+    "",
+    "Field rules:",
+    "- title: specific and concise, 12 words or fewer",
+    "- user_story: standard As a / I want / so that format",
+    "- description: practical implementation detail with expected behavior",
+    "- suggested_priority: exactly one of: low, medium, high, urgent",
+    "- suggested_story_points: integer between 1 and 100",
+    "- acceptance_criteria: array of 3 to 8 observable, testable strings",
+  ].join("\n");
+}

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -1,0 +1,70 @@
+import type { StoryPriority } from "@/lib/validators/story";
+
+export type AiStoryGeneratorInput = {
+  projectId: string;
+  featureIdea: string;
+  targetUser?: string | null;
+  businessGoal?: string | null;
+};
+
+export type GeneratedUserStory = {
+  title: string;
+  user_story: string;
+  description: string;
+  suggested_priority: StoryPriority;
+  suggested_story_points: number;
+  acceptance_criteria: string[];
+};
+
+export type AiStoryGeneratorResponse = {
+  story: GeneratedUserStory;
+};
+
+export const generatedUserStoryJsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    title: {
+      type: "string",
+      description: "A concise user story title, 12 words or fewer.",
+    },
+    user_story: {
+      type: "string",
+      description:
+        "A user story in the format: As a [user], I want [capability], so that [benefit].",
+    },
+    description: {
+      type: "string",
+      description:
+        "A practical implementation description with product context and expected behavior.",
+    },
+    suggested_priority: {
+      type: "string",
+      enum: ["low", "medium", "high", "urgent"],
+      description: "Suggested delivery priority.",
+    },
+    suggested_story_points: {
+      type: "integer",
+      minimum: 1,
+      maximum: 100,
+      description: "Suggested story point estimate.",
+    },
+    acceptance_criteria: {
+      type: "array",
+      minItems: 3,
+      maxItems: 8,
+      description: "Testable acceptance criteria.",
+      items: {
+        type: "string",
+      },
+    },
+  },
+  required: [
+    "title",
+    "user_story",
+    "description",
+    "suggested_priority",
+    "suggested_story_points",
+    "acceptance_criteria",
+  ],
+} as const;

--- a/src/lib/dashboard.ts
+++ b/src/lib/dashboard.ts
@@ -357,16 +357,16 @@ export const analyticsHighlights: AnalyticsHighlight[] = [
 
 export const assistantPrompts: AssistantPrompt[] = [
   {
-    label: "Summarize sprint health",
-    detail: "Future AI prompt for risks, blockers, and scope movement.",
+    label: "Generate user story",
+    detail: "Project workspaces can draft structured stories from feature ideas.",
   },
   {
-    label: "Draft standup notes",
-    detail: "Future assistant action for async team updates.",
+    label: "Copy into backlog",
+    detail: "Generated titles, descriptions, points, and criteria are copy-ready.",
   },
   {
-    label: "Find delivery risks",
-    detail: "Future prompt combining board activity and risk history.",
+    label: "Audit generation history",
+    detail: "Successful AI story drafts are logged to Supabase per project.",
   },
 ];
 
@@ -383,7 +383,7 @@ export const dashboardFocusItems = [
   },
   {
     label: "AI-ready surface",
-    detail: "Assistant space is designed, but no provider calls are made.",
+    detail: "Project workspaces can generate AI user story drafts through a protected server route.",
     Icon: Sparkles,
   },
 ];

--- a/src/lib/validators/ai-story.ts
+++ b/src/lib/validators/ai-story.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+
+import { storyPriorities } from "@/lib/validators/story";
+
+function normalizeOptionalText(value: unknown) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export const aiStoryGeneratorSchema = z.object({
+  projectId: z.uuid("Select a valid project."),
+  featureIdea: z
+    .string()
+    .trim()
+    .min(10, "Feature idea must be at least 10 characters.")
+    .max(800, "Feature idea must be 800 characters or fewer."),
+  targetUser: z.preprocess(
+    normalizeOptionalText,
+    z
+      .string()
+      .max(200, "Target user must be 200 characters or fewer.")
+      .nullable(),
+  ),
+  businessGoal: z.preprocess(
+    normalizeOptionalText,
+    z
+      .string()
+      .max(800, "Business goal must be 800 characters or fewer.")
+      .nullable(),
+  ),
+});
+
+export const generatedUserStorySchema = z.object({
+  title: z
+    .string()
+    .trim()
+    .min(3, "Generated title is too short.")
+    .max(180, "Generated title is too long."),
+  user_story: z
+    .string()
+    .trim()
+    .min(10, "Generated user story is too short.")
+    .max(500, "Generated user story is too long."),
+  description: z
+    .string()
+    .trim()
+    .min(10, "Generated description is too short.")
+    .max(2000, "Generated description is too long."),
+  suggested_priority: z.enum(storyPriorities),
+  suggested_story_points: z
+    .number()
+    .int("Generated story points must be a whole number.")
+    .min(1, "Generated story points must be at least 1.")
+    .max(100, "Generated story points must be 100 or fewer."),
+  acceptance_criteria: z
+    .array(z.string().trim().min(3).max(300))
+    .min(1, "Generated story must include acceptance criteria.")
+    .max(10, "Generated story has too many acceptance criteria."),
+});
+
+export type AiStoryGeneratorValues = z.infer<typeof aiStoryGeneratorSchema>;

--- a/supabase/migrations/20260503000500_add_user_story_generation_type.sql
+++ b/supabase/migrations/20260503000500_add_user_story_generation_type.sql
@@ -1,0 +1,13 @@
+alter table public.ai_generations
+  drop constraint ai_generations_type_check;
+
+alter table public.ai_generations
+  add constraint ai_generations_type_check
+    check (generation_type in (
+      'standup_summary',
+      'sprint_review',
+      'risk_analysis',
+      'story_breakdown',
+      'general',
+      'user_story'
+    ));


### PR DESCRIPTION
## Summary

This PR adds an AI-assisted user story generator to Minavolve project workspaces.

## Changes

- Added `/projects/[projectId]/ai/story-generator` page
- Added server-side AI generation route/action
- Added reusable AI user story generator form
- Added reusable generated story result card
- Added AI prompt/type helpers
- Added validation for feature idea input
- Generated structured Agile user story output
- Logged successful generations in Supabase `ai_generations`
- Added project workspace navigation to the AI generator
- Preserved manual story creation flow
- Updated README with AI setup instructions
- Updated `.env.example` for AI configuration

## Testing

- Ran `npm run lint`
- Ran `npm run dev`
- Confirmed `OPENAI_API_KEY` exists in `.env.local`
- Logged in with a test user
- Opened an existing project workspace
- Verified AI generator link appears
- Opened `/projects/[projectId]/ai/story-generator`
- Submitted a valid feature idea
- Verified generated story output appears
- Verified output includes title, user story, description, priority, story points, and acceptance criteria
- Verified a row appears in Supabase `ai_generations`
- Verified `generation_type` is `user_story`
- Verified `project_id` and `user_id` are correct
- Verified invalid feature ideas show validation errors
- Verified missing API key handling if tested
- Verified manual story creation still works
- Verified Kanban drag-and-drop still works
- Verified logged-out users cannot access the AI generator route
- Verified `/`, `/login`, `/register`, `/dashboard`, `/projects`, project workspace, sprint routes, story routes, and Kanban route still work

Closes #20 