### PR TITLE
feat(ai): add AI acceptance criteria generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Minavolve
 
-Minavolve is an Agile sprint board product concept with an AI-assisted backlog workflow. This repository currently ships a polished landing page, Supabase email/password authentication, an authenticated dashboard layout, initial Supabase-backed project/sprint/user story creation and listing, a drag-and-drop Kanban board that persists story status and order, and an AI user story generator for project workspaces.
+Minavolve is an Agile sprint board product concept with an AI-assisted backlog workflow. This repository currently ships a polished landing page, Supabase email/password authentication, an authenticated dashboard layout, initial Supabase-backed project/sprint/user story creation and listing, a drag-and-drop Kanban board that persists story status and order, an AI user story generator, and an AI acceptance criteria generator for project workspaces.
 
 ## What this issue includes
 
@@ -15,6 +15,7 @@ Minavolve is an Agile sprint board product concept with an AI-assisted backlog w
 - Project-scoped user story listing, story creation, optional sprint assignment, and a basic story workspace placeholder backed by Supabase RLS
 - Project-scoped drag-and-drop Kanban board grouped by user story status
 - Project-scoped AI user story generator backed by a protected server API route
+- Project-scoped AI acceptance criteria generator backed by a protected server API route
 - Starter environment variable documentation in `.env.example`
 - Initial Supabase schema migration for projects, sprints, stories, risks, AI generations, activity, memberships, and profiles
 
@@ -25,7 +26,8 @@ Minavolve is an Agile sprint board product concept with an AI-assisted backlog w
 - No user story editing or deletion
 - No story editing, deletion, or assignee workflows from the Kanban board
 - No charts or risk register CRUD
-- No acceptance criteria-only generator, story auto-insert, charts, or risk AI workflows
+- No story auto-insert from AI output
+- No charts or risk AI workflows
 
 ## Tech stack
 
@@ -97,6 +99,7 @@ npm run lint
 - `/projects/[projectId]/stories/[storyId]`: protected user story workspace placeholder
 - `/projects/[projectId]/kanban`: protected project-specific Kanban board grouped by story status
 - `/projects/[projectId]/ai/story-generator`: protected AI user story generator
+- `/projects/[projectId]/ai/acceptance-criteria`: protected AI acceptance criteria generator
 
 ## Dashboard status
 
@@ -178,14 +181,31 @@ Issue #20 adds a project-scoped AI story generator:
 - `/projects/[projectId]/ai/story-generator` is protected by the existing Supabase server-side user check.
 - The generator accepts a required feature idea plus optional target user/persona and business goal context.
 - Input is validated with Zod before the provider call.
-- Client components call Minavolve's protected `/api/ai/user-story` route; `OPENAI_API_KEY` is read only on the server.
-- The API route uses the OpenAI Responses API with structured JSON output for title, user story, description, suggested priority, suggested story points, and acceptance criteria.
+- Client components call Minavolve's protected `/api/ai/user-story` route; `GROQ_API_KEY` is read only on the server.
+- The API route calls Groq Chat Completions with `response_format: json_object` for title, user story, description, suggested priority, suggested story points, and acceptance criteria.
 - Successful generations are logged to `public.ai_generations` for the selected project when the cloud schema supports `generation_type = 'user_story'`.
 - Generated output is copy-ready and links back to the manual story creation form.
 
-The generator intentionally does not insert user stories automatically, edit existing stories, generate acceptance criteria independently, or add broader assistant workflows.
+The generator intentionally does not insert user stories automatically, edit existing stories, or add broader assistant workflows.
 
-If generation logging returns an `ai_generations_type_check` or missing column message, confirm the Supabase cloud `public.ai_generations` table supports the Issue #20 logging shape before retesting. This issue does not add or modify migration files.
+Apply migration `20260503000500_add_user_story_generation_type.sql` in the Supabase cloud SQL editor to enable generation logging.
+
+## AI acceptance criteria generator status
+
+Issue #11 adds a project-scoped AI acceptance criteria generator:
+
+- `/projects/[projectId]/ai/acceptance-criteria` is protected by the existing Supabase server-side user check.
+- The generator accepts a required user story title (minimum 10 characters) plus optional story description or context.
+- Input is validated with Zod before the provider call.
+- Client components call Minavolve's protected `/api/ai/acceptance-criteria` route; `GROQ_API_KEY` is read only on the server.
+- The API route calls Groq Chat Completions with `response_format: json_object` and returns 3 to 8 testable acceptance criteria.
+- Successful generations are logged to `public.ai_generations` with `generation_type = 'acceptance_criteria'`.
+- Each criterion can be copied individually, or the full list can be copied in one click.
+- The AC generator is linked from the project workspace header, the user stories backlog section, and individual story detail pages.
+
+The generator intentionally does not insert criteria automatically into existing stories or add broader assistant workflows.
+
+Apply migration `20260503000600_add_acceptance_criteria_generation_type.sql` in the Supabase cloud SQL editor to enable generation logging.
 
 ## Environment variables
 

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -234,7 +234,7 @@ export default async function DashboardPage() {
                 id="ai-assistant"
                 eyebrow="Assistant"
                 title="AI assistant"
-                description="Project workspaces now include an AI user story generator that calls OpenAI from a protected server route and logs successful generations."
+                description="Project workspaces include an AI user story generator and an AI acceptance criteria generator. Both call Groq from a protected server route and log successful generations."
                 dark
               >
                 <div className="space-y-3">

--- a/src/app/(app)/projects/[projectId]/ai/acceptance-criteria/actions.ts
+++ b/src/app/(app)/projects/[projectId]/ai/acceptance-criteria/actions.ts
@@ -1,0 +1,35 @@
+"use server";
+
+import { notFound, redirect } from "next/navigation";
+
+import { createClient } from "@/utils/supabase/server";
+
+export type AcceptanceCriteriaGeneratorProject = {
+  id: string;
+  name: string;
+  project_key: string;
+  description: string | null;
+};
+
+export async function getAcceptanceCriteriaGeneratorProject(projectId: string) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { data: project, error } = await supabase
+    .from("projects")
+    .select("id,name,project_key,description")
+    .eq("id", projectId)
+    .maybeSingle();
+
+  if (error || !project) {
+    notFound();
+  }
+
+  return project as AcceptanceCriteriaGeneratorProject;
+}

--- a/src/app/(app)/projects/[projectId]/ai/acceptance-criteria/page.tsx
+++ b/src/app/(app)/projects/[projectId]/ai/acceptance-criteria/page.tsx
@@ -1,0 +1,84 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft, Bot, MessageSquarePlus } from "lucide-react";
+
+import { getAcceptanceCriteriaGeneratorProject } from "@/app/(app)/projects/[projectId]/ai/acceptance-criteria/actions";
+import { AppSidebar } from "@/components/app/app-sidebar";
+import { AcceptanceCriteriaGeneratorForm } from "@/components/ai/acceptance-criteria-generator-form";
+import { Button } from "@/components/ui/button";
+
+export const metadata: Metadata = {
+  title: "AI acceptance criteria generator",
+  description:
+    "Generate testable acceptance criteria for an Agile user story.",
+};
+
+type AcceptanceCriteriaGeneratorPageProps = {
+  params: Promise<{
+    projectId: string;
+  }>;
+};
+
+export default async function AcceptanceCriteriaGeneratorPage({
+  params,
+}: AcceptanceCriteriaGeneratorPageProps) {
+  const { projectId } = await params;
+  const project = await getAcceptanceCriteriaGeneratorProject(projectId);
+
+  return (
+    <main className="min-h-screen px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto flex w-full max-w-[1540px] flex-col gap-6 lg:flex-row">
+        <div className="lg:w-72 lg:shrink-0">
+          <AppSidebar activeHref="/projects" />
+        </div>
+
+        <div className="min-w-0 flex-1 space-y-6">
+          <Link
+            href={`/projects/${project.id}`}
+            className="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition-colors hover:text-slate-950"
+          >
+            <ArrowLeft className="size-4" />
+            Back to project
+          </Link>
+
+          <header className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6">
+            <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
+              <div className="flex items-start gap-4">
+                <div className="inline-flex size-12 items-center justify-center rounded-2xl bg-slate-950 text-white">
+                  <Bot className="size-6" />
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-brand">
+                    {project.project_key} AI workflow
+                  </p>
+                  <h1 className="mt-2 font-heading text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                    AI acceptance criteria generator
+                  </h1>
+                  <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
+                    Turn a user story title into 3 to 8 testable acceptance
+                    criteria for {project.name}. The result is copy-ready for
+                    the manual story form and logged to this project&apos;s AI
+                    generation history.
+                  </p>
+                </div>
+              </div>
+
+              <Button
+                asChild
+                size="lg"
+                className="h-10 rounded-2xl bg-slate-950 px-4 text-white hover:bg-slate-800"
+              >
+                <Link href={`/projects/${project.id}/stories/new`}>
+                  <MessageSquarePlus className="size-4" />
+                  Manual story form
+                </Link>
+              </Button>
+            </div>
+          </header>
+
+          <AcceptanceCriteriaGeneratorForm projectId={project.id} />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(app)/projects/[projectId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/page.tsx
@@ -6,6 +6,7 @@ import {
   ClipboardList,
   Columns3,
   FolderKanban,
+  ListChecks,
   MessageSquarePlus,
   MessageSquareText,
   Plus,
@@ -196,6 +197,18 @@ export default async function ProjectWorkspacePage({
                 <Button
                   asChild
                   size="lg"
+                  className="h-10 rounded-2xl border border-cyan-200 bg-cyan-50 px-4 text-cyan-950 hover:bg-cyan-100"
+                >
+                  <Link
+                    href={`/projects/${typedProject.id}/ai/acceptance-criteria`}
+                  >
+                    <ListChecks className="size-4" />
+                    AI criteria generator
+                  </Link>
+                </Button>
+                <Button
+                  asChild
+                  size="lg"
                   className="h-10 rounded-2xl bg-slate-950 px-4 text-white hover:bg-slate-800"
                 >
                   <Link href={`/projects/${typedProject.id}/kanban`}>
@@ -350,6 +363,18 @@ export default async function ProjectWorkspacePage({
                   >
                     <Sparkles className="size-4" />
                     Generate story
+                  </Link>
+                </Button>
+                <Button
+                  asChild
+                  size="lg"
+                  className="h-10 rounded-2xl border border-cyan-200 bg-cyan-50 px-4 text-cyan-950 hover:bg-cyan-100"
+                >
+                  <Link
+                    href={`/projects/${typedProject.id}/ai/acceptance-criteria`}
+                  >
+                    <ListChecks className="size-4" />
+                    Generate criteria
                   </Link>
                 </Button>
                 <Button

--- a/src/app/(app)/projects/[projectId]/stories/[storyId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/stories/[storyId]/page.tsx
@@ -7,6 +7,7 @@ import {
   Columns3,
   Flag,
   Gauge,
+  ListChecks,
   MessageSquareText,
 } from "lucide-react";
 import { notFound, redirect } from "next/navigation";
@@ -144,13 +145,22 @@ export default async function StoryDetailPage({
             </div>
           </header>
 
-          <Link
-            href={`/projects/${typedProject.id}/kanban`}
-            className="inline-flex w-fit items-center gap-2 rounded-2xl bg-slate-950 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-slate-800"
-          >
-            <Columns3 className="size-4" />
-            Open Kanban board
-          </Link>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href={`/projects/${typedProject.id}/kanban`}
+              className="inline-flex w-fit items-center gap-2 rounded-2xl bg-slate-950 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-slate-800"
+            >
+              <Columns3 className="size-4" />
+              Open Kanban board
+            </Link>
+            <Link
+              href={`/projects/${typedProject.id}/ai/acceptance-criteria`}
+              className="inline-flex w-fit items-center gap-2 rounded-2xl border border-cyan-200 bg-cyan-50 px-4 py-2.5 text-sm font-semibold text-cyan-950 transition-colors hover:bg-cyan-100"
+            >
+              <ListChecks className="size-4" />
+              Generate acceptance criteria
+            </Link>
+          </div>
 
           <section className="grid gap-5 md:grid-cols-4">
             {[

--- a/src/app/api/ai/acceptance-criteria/route.ts
+++ b/src/app/api/ai/acceptance-criteria/route.ts
@@ -1,0 +1,237 @@
+import { NextResponse } from "next/server";
+
+import {
+  acceptanceCriteriaGeneratorInstructions,
+  buildAcceptanceCriteriaPrompt,
+} from "@/lib/ai/prompts";
+import { type GeneratedCriteria } from "@/lib/ai/types";
+import {
+  aiCriteriaGeneratorSchema,
+  generatedCriteriaSchema,
+} from "@/lib/validators/ai-story";
+import { createClient } from "@/utils/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+type GroqResponseBody = {
+  error?: { message?: string } | null;
+  model?: string;
+  choices?: Array<{
+    message?: { content?: string };
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+  };
+};
+
+function jsonError(message: string, status = 400) {
+  return NextResponse.json({ error: message }, { status });
+}
+
+function getProviderErrorMessage(status: number, message?: string) {
+  if (status === 401) {
+    return "Groq rejected the API key. Check GROQ_API_KEY in the server environment.";
+  }
+
+  if (status === 429) {
+    return "Groq rate limits were reached. Wait briefly and try again.";
+  }
+
+  if (message) {
+    return `Groq could not generate criteria: ${message}`;
+  }
+
+  return "Groq could not generate criteria right now. Try again shortly.";
+}
+
+function getGenerationLogError(message: string) {
+  const normalized = message.toLowerCase();
+
+  if (
+    normalized.includes("generation_type") ||
+    normalized.includes("violates check constraint")
+  ) {
+    return "The ai_generations table does not currently allow generation_type = 'acceptance_criteria'. Apply migration 20260503000600 in the Supabase cloud SQL editor before retesting.";
+  }
+
+  if (normalized.includes("row-level security")) {
+    return "Supabase blocked the generation log. Confirm you are still a project member and the AI generation RLS policies are applied.";
+  }
+
+  return "Criteria were generated, but Minavolve could not save the generation log.";
+}
+
+async function logGeneration({
+  criteria,
+  inputTokens,
+  model,
+  outputTokens,
+  projectId,
+  prompt,
+  supabase,
+  userId,
+}: {
+  criteria: GeneratedCriteria;
+  inputTokens?: number;
+  model: string;
+  outputTokens?: number;
+  projectId: string;
+  prompt: string;
+  supabase: Awaited<ReturnType<typeof createClient>>;
+  userId: string;
+}) {
+  const { error } = await supabase.from("ai_generations").insert({
+    project_id: projectId,
+    requested_by: userId,
+    generation_type: "acceptance_criteria",
+    prompt,
+    response: JSON.stringify(criteria),
+    provider: "groq",
+    model,
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    status: "completed",
+  });
+
+  if (error) {
+    throw new Error(getGenerationLogError(error.message));
+  }
+}
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return jsonError("Sign in before generating acceptance criteria.", 401);
+  }
+
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError("Send valid JSON to generate acceptance criteria.");
+  }
+
+  const parsed = aiCriteriaGeneratorSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return jsonError(
+      parsed.error.issues[0]?.message ?? "Enter valid generator details.",
+    );
+  }
+
+  const { data: project, error: projectError } = await supabase
+    .from("projects")
+    .select("id,name,project_key")
+    .eq("id", parsed.data.projectId)
+    .maybeSingle();
+
+  if (projectError || !project) {
+    return jsonError(
+      "Project not found or you do not have access to generate criteria for it.",
+      404,
+    );
+  }
+
+  const apiKey = process.env.GROQ_API_KEY?.trim();
+
+  if (!apiKey) {
+    return jsonError(
+      "GROQ_API_KEY is missing. Add it to .env.local and restart the dev server.",
+      503,
+    );
+  }
+
+  const model = process.env.GROQ_MODEL ?? "llama-3.3-70b-versatile";
+  const prompt = buildAcceptanceCriteriaPrompt(parsed.data);
+
+  const providerResponse = await fetch(
+    "https://api.groq.com/openai/v1/chat/completions",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        temperature: 0.7,
+        response_format: { type: "json_object" },
+        messages: [
+          { role: "system", content: acceptanceCriteriaGeneratorInstructions },
+          { role: "user", content: prompt },
+        ],
+      }),
+    },
+  );
+
+  const providerJson = (await providerResponse
+    .json()
+    .catch(() => null)) as GroqResponseBody | null;
+
+  if (!providerResponse.ok || !providerJson) {
+    return jsonError(
+      getProviderErrorMessage(
+        providerResponse.status,
+        providerJson?.error?.message,
+      ),
+      providerResponse.status || 502,
+    );
+  }
+
+  const rawText = providerJson.choices?.[0]?.message?.content ?? "";
+
+  if (!rawText) {
+    return jsonError(
+      "Groq returned an empty response. Try generating criteria again.",
+      502,
+    );
+  }
+
+  let rawCriteria: unknown;
+
+  try {
+    rawCriteria = JSON.parse(rawText);
+  } catch {
+    return jsonError(
+      "Groq returned a response Minavolve could not parse as JSON.",
+      502,
+    );
+  }
+
+  const generated = generatedCriteriaSchema.safeParse(rawCriteria);
+
+  if (!generated.success) {
+    return jsonError(
+      "Groq returned criteria that did not match the expected structure. Try again.",
+      502,
+    );
+  }
+
+  try {
+    await logGeneration({
+      criteria: generated.data,
+      inputTokens: providerJson.usage?.prompt_tokens,
+      model: providerJson.model ?? model,
+      outputTokens: providerJson.usage?.completion_tokens,
+      projectId: parsed.data.projectId,
+      prompt,
+      supabase,
+      userId: user.id,
+    });
+  } catch (error) {
+    return jsonError(
+      error instanceof Error
+        ? error.message
+        : "Criteria were generated, but Minavolve could not save the generation log.",
+      500,
+    );
+  }
+
+  return NextResponse.json({ criteria: generated.data });
+}

--- a/src/components/ai/acceptance-criteria-generator-form.tsx
+++ b/src/components/ai/acceptance-criteria-generator-form.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import { Loader2, ListChecks } from "lucide-react";
+
+import { GeneratedCriteriaCard } from "@/components/ai/generated-criteria-card";
+import { Button } from "@/components/ui/button";
+import type { GeneratedCriteria } from "@/lib/ai/types";
+import { aiCriteriaGeneratorSchema } from "@/lib/validators/ai-story";
+
+type AcceptanceCriteriaGeneratorFormProps = {
+  projectId: string;
+};
+
+type AiCriteriaApiResponse = {
+  criteria?: GeneratedCriteria;
+  error?: string;
+};
+
+export function AcceptanceCriteriaGeneratorForm({
+  projectId,
+}: AcceptanceCriteriaGeneratorFormProps) {
+  const [storyTitle, setStoryTitle] = useState("");
+  const [storyContext, setStoryContext] = useState("");
+  const [generatedCriteria, setGeneratedCriteria] =
+    useState<GeneratedCriteria | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setGeneratedCriteria(null);
+
+    const payload = { projectId, storyTitle, storyContext };
+    const parsed = aiCriteriaGeneratorSchema.safeParse(payload);
+
+    if (!parsed.success) {
+      setError(
+        parsed.error.issues[0]?.message ?? "Enter valid generator details.",
+      );
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const response = await fetch("/api/ai/acceptance-criteria", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(parsed.data),
+      });
+      const data = (await response.json()) as AiCriteriaApiResponse;
+
+      if (!response.ok || !data.criteria) {
+        setError(data.error ?? "Unable to generate acceptance criteria right now.");
+        return;
+      }
+
+      setGeneratedCriteria(data.criteria);
+    } catch {
+      setError("Network error while generating criteria. Try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <div className="grid gap-6 xl:grid-cols-[minmax(0,0.9fr)_minmax(420px,1.1fr)]">
+      <form
+        onSubmit={handleSubmit}
+        className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6"
+      >
+        {error ? (
+          <div className="mb-6 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm leading-6 text-rose-800">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="grid gap-5">
+          <label className="block text-sm font-semibold text-slate-800">
+            User story title
+            <input
+              required
+              minLength={10}
+              maxLength={180}
+              value={storyTitle}
+              onChange={(event) => setStoryTitle(event.target.value)}
+              placeholder="Example: Let project managers assign story points during sprint planning"
+              className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+            />
+            <span className="mt-2 block text-xs font-normal leading-5 text-slate-500">
+              Required. Use 10 to 180 characters.
+            </span>
+          </label>
+
+          <label className="block text-sm font-semibold text-slate-800">
+            Story description or context
+            <textarea
+              maxLength={800}
+              rows={6}
+              value={storyContext}
+              onChange={(event) => setStoryContext(event.target.value)}
+              placeholder="Example: The team needs to estimate effort before committing to a sprint. Story points use Fibonacci scale."
+              className="mt-2 w-full resize-y rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm leading-6 text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+            />
+            <span className="mt-2 block text-xs font-normal leading-5 text-slate-500">
+              Optional. Max 800 characters.
+            </span>
+          </label>
+        </div>
+
+        <div className="mt-7 flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-sm leading-6 text-slate-500">
+            Generated criteria are logged to Supabase for the current project.
+          </p>
+          <Button
+            type="submit"
+            size="lg"
+            disabled={isLoading}
+            className="h-11 rounded-2xl bg-slate-950 px-5 text-white hover:bg-slate-800"
+          >
+            {isLoading ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <ListChecks className="size-4" />
+            )}
+            {isLoading ? "Generating..." : "Generate criteria"}
+          </Button>
+        </div>
+      </form>
+
+      {generatedCriteria ? (
+        <GeneratedCriteriaCard
+          projectId={projectId}
+          criteria={generatedCriteria}
+        />
+      ) : (
+        <aside className="rounded-[2rem] border border-white/80 bg-slate-950 p-6 text-white shadow-[0_25px_80px_-55px_rgba(15,23,42,0.9)]">
+          <div className="inline-flex size-12 items-center justify-center rounded-2xl bg-white/10 text-cyan-200">
+            <ListChecks className="size-6" />
+          </div>
+          <h2 className="mt-5 font-heading text-2xl font-semibold">
+            What Minavolve generates
+          </h2>
+          <p className="mt-3 text-sm leading-6 text-slate-300">
+            The assistant returns 3 to 8 testable acceptance criteria scoped to
+            the story title. Each criterion is observable and verifiable by a
+            tester.
+          </p>
+          <div className="mt-5 rounded-2xl border border-white/10 bg-white/[0.06] p-4 text-sm leading-6 text-slate-300">
+            GROQ_API_KEY is read only from server environment variables. Client
+            components call Minavolve&apos;s protected API route instead of the
+            provider directly.
+          </div>
+        </aside>
+      )}
+    </div>
+  );
+}

--- a/src/components/ai/generated-criteria-card.tsx
+++ b/src/components/ai/generated-criteria-card.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Check, Clipboard, ExternalLink, ListChecks } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import type { GeneratedCriteria } from "@/lib/ai/types";
+
+type GeneratedCriteriaCardProps = {
+  projectId: string;
+  criteria: GeneratedCriteria;
+};
+
+export function GeneratedCriteriaCard({
+  projectId,
+  criteria,
+}: GeneratedCriteriaCardProps) {
+  const [copiedAll, setCopiedAll] = useState(false);
+  const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
+
+  async function copyAll() {
+    const text = criteria.acceptance_criteria
+      .map((item, i) => `${i + 1}. ${item}`)
+      .join("\n");
+    await navigator.clipboard.writeText(text);
+    setCopiedAll(true);
+    window.setTimeout(() => setCopiedAll(false), 1800);
+  }
+
+  async function copyItem(item: string, index: number) {
+    await navigator.clipboard.writeText(item);
+    setCopiedIndex(index);
+    window.setTimeout(() => setCopiedIndex(null), 1800);
+  }
+
+  return (
+    <article className="rounded-[2rem] border border-cyan-200/80 bg-cyan-50/80 p-5 shadow-[0_25px_80px_-55px_rgba(14,116,144,0.8)] sm:p-6">
+      <div className="flex items-start justify-between gap-4">
+        <p className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-cyan-800">
+          <ListChecks className="size-4" />
+          Generated criteria
+        </p>
+        <span className="rounded-full bg-white px-3 py-1.5 text-xs font-semibold text-cyan-900">
+          {criteria.acceptance_criteria.length} items
+        </span>
+      </div>
+
+      <ul className="mt-5 space-y-3">
+        {criteria.acceptance_criteria.map((item, index) => (
+          <li
+            key={`${item}-${index}`}
+            className="flex items-start gap-3 rounded-2xl border border-cyan-100 bg-white/80 px-4 py-3"
+          >
+            <Check className="mt-0.5 size-4 shrink-0 text-cyan-700" />
+            <span className="flex-1 text-sm leading-6 text-slate-700">
+              {item}
+            </span>
+            <button
+              type="button"
+              onClick={() => copyItem(item, index)}
+              aria-label="Copy this criterion"
+              className="ml-2 shrink-0 text-slate-400 transition-colors hover:text-cyan-700"
+            >
+              {copiedIndex === index ? (
+                <Check className="size-4 text-emerald-600" />
+              ) : (
+                <Clipboard className="size-4" />
+              )}
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm leading-6 text-cyan-900">
+          Copy criteria into the manual story form.
+        </p>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <Button
+            type="button"
+            variant="outline"
+            size="lg"
+            onClick={copyAll}
+            className="h-11 rounded-2xl border-cyan-200 bg-white px-5 text-cyan-950 hover:bg-cyan-50"
+          >
+            {copiedAll ? (
+              <Check className="size-4" />
+            ) : (
+              <Clipboard className="size-4" />
+            )}
+            {copiedAll ? "Copied" : "Copy all"}
+          </Button>
+          <Button
+            asChild
+            size="lg"
+            className="h-11 rounded-2xl bg-slate-950 px-5 text-white hover:bg-slate-800"
+          >
+            <Link href={`/projects/${projectId}/stories/new`}>
+              <ExternalLink className="size-4" />
+              Open new story form
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -1,4 +1,34 @@
-import type { AiStoryGeneratorInput } from "@/lib/ai/types";
+import type {
+  AiCriteriaGeneratorInput,
+  AiStoryGeneratorInput,
+} from "@/lib/ai/types";
+
+export const acceptanceCriteriaGeneratorInstructions = [
+  "You are Minavolve's Agile product assistant.",
+  "Generate testable acceptance criteria for an Agile user story.",
+  "Each criterion must be observable, specific, and verifiable by a tester.",
+  "Do not mention that you are an AI assistant.",
+  "Return ONLY the raw JSON object — no markdown, no code fences, no explanation, no wrapper key.",
+].join(" ");
+
+export function buildAcceptanceCriteriaPrompt(input: AiCriteriaGeneratorInput) {
+  const context = input.storyContext?.trim() || "Not specified";
+
+  return [
+    "Generate acceptance criteria for this user story.",
+    "",
+    `Story title: ${input.storyTitle.trim()}`,
+    `Additional context: ${context}`,
+    "",
+    "Return ONLY a flat JSON object with exactly this key — no wrapper, no extra fields:",
+    '{"acceptance_criteria":["...","...","..."]}',
+    "",
+    "Field rules:",
+    "- acceptance_criteria: array of 3 to 8 observable, testable strings",
+    "- Each criterion should begin with a clear observable condition or action verb",
+    "- Be specific and verifiable — avoid vague language",
+  ].join("\n");
+}
 
 export const userStoryGeneratorInstructions = [
   "You are Minavolve's Agile product assistant.",

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -1,5 +1,19 @@
 import type { StoryPriority } from "@/lib/validators/story";
 
+export type AiCriteriaGeneratorInput = {
+  projectId: string;
+  storyTitle: string;
+  storyContext?: string | null;
+};
+
+export type GeneratedCriteria = {
+  acceptance_criteria: string[];
+};
+
+export type AiCriteriaGeneratorResponse = {
+  criteria: GeneratedCriteria;
+};
+
 export type AiStoryGeneratorInput = {
   projectId: string;
   featureIdea: string;

--- a/src/lib/dashboard.ts
+++ b/src/lib/dashboard.ts
@@ -361,12 +361,16 @@ export const assistantPrompts: AssistantPrompt[] = [
     detail: "Project workspaces can draft structured stories from feature ideas.",
   },
   {
+    label: "Generate acceptance criteria",
+    detail: "Project workspaces can generate 3 to 8 testable criteria from a story title.",
+  },
+  {
     label: "Copy into backlog",
     detail: "Generated titles, descriptions, points, and criteria are copy-ready.",
   },
   {
     label: "Audit generation history",
-    detail: "Successful AI story drafts are logged to Supabase per project.",
+    detail: "Successful AI generations are logged to Supabase per project.",
   },
 ];
 

--- a/src/lib/validators/ai-story.ts
+++ b/src/lib/validators/ai-story.ts
@@ -63,3 +63,25 @@ export const generatedUserStorySchema = z.object({
 });
 
 export type AiStoryGeneratorValues = z.infer<typeof aiStoryGeneratorSchema>;
+
+export const aiCriteriaGeneratorSchema = z.object({
+  projectId: z.uuid("Select a valid project."),
+  storyTitle: z
+    .string()
+    .trim()
+    .min(10, "Story title must be at least 10 characters.")
+    .max(180, "Story title must be 180 characters or fewer."),
+  storyContext: z.preprocess(
+    normalizeOptionalText,
+    z.string().max(800, "Context must be 800 characters or fewer.").nullable(),
+  ),
+});
+
+export const generatedCriteriaSchema = z.object({
+  acceptance_criteria: z
+    .array(z.string().trim().min(3).max(400))
+    .min(3, "At least 3 acceptance criteria are required.")
+    .max(8, "Too many acceptance criteria returned."),
+});
+
+export type AiCriteriaGeneratorValues = z.infer<typeof aiCriteriaGeneratorSchema>;

--- a/supabase/migrations/20260503000600_add_acceptance_criteria_generation_type.sql
+++ b/supabase/migrations/20260503000600_add_acceptance_criteria_generation_type.sql
@@ -1,0 +1,14 @@
+alter table public.ai_generations
+  drop constraint ai_generations_type_check;
+
+alter table public.ai_generations
+  add constraint ai_generations_type_check
+    check (generation_type in (
+      'standup_summary',
+      'sprint_review',
+      'risk_analysis',
+      'story_breakdown',
+      'general',
+      'user_story',
+      'acceptance_criteria'
+    ));


### PR DESCRIPTION
## Summary
Adds an AI-powered acceptance criteria generator to Minavolve project workspaces.

## Changes
- Added /projects/[projectId]/ai/acceptance-criteria page
- Added server-side Groq API route for AC generation
- Added AC generator form with validation
- Added generated criteria card with copy support
- Logged generations to Supabase ai_generations (type: acceptance_criteria)
- Added AC generator link from project workspace
- Added AC generator link from story detail page
- Existing user story generator unchanged
- Updated README

## Testing
- npm run lint ✓
- npm run dev ✓
- Submitted valid story title → 3–8 criteria returned ✓
- Supabase ai_generations row confirmed with correct type/project/user ✓
- Validation blocks empty/short input ✓
- User story generator still works ✓
- Kanban drag-and-drop still works ✓
- Route protected from logged-out users ✓
- All existing routes still work ✓

Closes #22 