### PR TITLE
feat(charts): add sprint velocity chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Minavolve
 
-Minavolve is an Agile sprint board product concept with an AI-assisted backlog workflow. This repository currently ships a polished landing page, Supabase email/password authentication, an authenticated dashboard layout, initial Supabase-backed project/sprint/user story creation and listing, a drag-and-drop Kanban board that persists story status and order, an AI user story generator, and an AI acceptance criteria generator for project workspaces.
+Minavolve is an Agile sprint board product concept with an AI-assisted backlog workflow. This repository currently ships a polished landing page, Supabase email/password authentication, an authenticated dashboard layout, initial Supabase-backed project/sprint/user story creation and listing, a drag-and-drop Kanban board that persists story status and order, an AI user story generator, an AI acceptance criteria generator, and a sprint velocity chart for project workspaces.
 
 ## What this issue includes
 
@@ -16,6 +16,7 @@ Minavolve is an Agile sprint board product concept with an AI-assisted backlog w
 - Project-scoped drag-and-drop Kanban board grouped by user story status
 - Project-scoped AI user story generator backed by a protected server API route
 - Project-scoped AI acceptance criteria generator backed by a protected server API route
+- Project-scoped sprint velocity chart showing completed story points per sprint
 - Starter environment variable documentation in `.env.example`
 - Initial Supabase schema migration for projects, sprints, stories, risks, AI generations, activity, memberships, and profiles
 
@@ -25,9 +26,10 @@ Minavolve is an Agile sprint board product concept with an AI-assisted backlog w
 - No sprint editing or deletion
 - No user story editing or deletion
 - No story editing, deletion, or assignee workflows from the Kanban board
-- No charts or risk register CRUD
+- No burndown chart yet
+- No risk register CRUD yet
 - No story auto-insert from AI output
-- No charts or risk AI workflows
+- No risk AI workflows
 
 ## Tech stack
 
@@ -64,7 +66,6 @@ Minavolve is an Agile sprint board product concept with an AI-assisted backlog w
    ```
 
 4. Open the app in your browser:
-
    - `http://localhost:3000/`
    - `http://localhost:3000/login`
    - `http://localhost:3000/register`
@@ -100,6 +101,7 @@ npm run lint
 - `/projects/[projectId]/kanban`: protected project-specific Kanban board grouped by story status
 - `/projects/[projectId]/ai/story-generator`: protected AI user story generator
 - `/projects/[projectId]/ai/acceptance-criteria`: protected AI acceptance criteria generator
+- `/projects/[projectId]/analytics/velocity`: protected sprint velocity chart
 
 ## Dashboard status
 
@@ -192,7 +194,7 @@ Apply migration `20260503000500_add_user_story_generation_type.sql` in the Supab
 
 ## AI acceptance criteria generator status
 
-Issue #11 adds a project-scoped AI acceptance criteria generator:
+Issue #22 adds a project-scoped AI acceptance criteria generator:
 
 - `/projects/[projectId]/ai/acceptance-criteria` is protected by the existing Supabase server-side user check.
 - The generator accepts a required user story title (minimum 10 characters) plus optional story description or context.
@@ -206,6 +208,23 @@ Issue #11 adds a project-scoped AI acceptance criteria generator:
 The generator intentionally does not insert criteria automatically into existing stories or add broader assistant workflows.
 
 Apply migration `20260503000600_add_acceptance_criteria_generation_type.sql` in the Supabase cloud SQL editor to enable generation logging.
+
+## Sprint velocity chart status
+
+Issue #24 adds a project-scoped sprint velocity chart:
+
+- `/projects/[projectId]/analytics/velocity` is protected by the existing Supabase server-side user check.
+- The page fetches all sprints for the project and all user stories with `status = 'done'`.
+- Data is aggregated server-side using `buildVelocityData` in `src/lib/charts.ts` — no client-side data fetching.
+- The `VelocityChart` component is a `"use client"` Recharts `BarChart` that receives pre-aggregated data.
+- Each bar represents one sprint; the Y-axis shows completed story points.
+- A custom tooltip shows sprint name and point total on hover.
+- A clear empty state appears when no sprint has any Done stories.
+- Summary tiles show sprints tracked, total completed points, and average velocity.
+- The velocity page is linked from the project workspace header as a Velocity button.
+- No migration is needed — the chart reads from existing `public.sprints` and `public.user_stories` fields.
+
+The chart intentionally does not implement burndown, cumulative flow, or risk analytics.
 
 ## Environment variables
 
@@ -262,7 +281,6 @@ The migration is designed for a Supabase cloud project. It creates the public ap
 4. Paste the full SQL into a new query.
 5. Run the query.
 6. Confirm these tables exist in the `public` schema:
-
    - `profiles`
    - `projects`
    - `project_members`

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -206,7 +206,7 @@ export default async function DashboardPage() {
                 id="delivery-analytics"
                 eyebrow="Analytics"
                 title="Delivery analytics"
-                description="Charting is out of scope, so this section uses static KPI tiles only."
+                description="Sprint velocity charts are available in project workspaces. This dashboard section keeps static KPI tiles."
               >
                 <div className="grid gap-3">
                   {analyticsHighlights.map((item) => (

--- a/src/app/(app)/projects/[projectId]/analytics/velocity/page.tsx
+++ b/src/app/(app)/projects/[projectId]/analytics/velocity/page.tsx
@@ -1,0 +1,168 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft, BarChart3, Plus } from "lucide-react";
+import { notFound, redirect } from "next/navigation";
+
+import { AppSidebar } from "@/components/app/app-sidebar";
+import { VelocityChart } from "@/components/charts/velocity-chart";
+import { Button } from "@/components/ui/button";
+import { buildVelocityData } from "@/lib/charts";
+import { createClient } from "@/utils/supabase/server";
+
+export const metadata: Metadata = {
+  title: "Sprint velocity",
+  description: "Sprint velocity chart for a Minavolve project.",
+};
+
+type VelocityPageProps = {
+  params: Promise<{
+    projectId: string;
+  }>;
+};
+
+export default async function VelocityPage({ params }: VelocityPageProps) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { projectId } = await params;
+
+  const { data: project, error: projectError } = await supabase
+    .from("projects")
+    .select("id,name,project_key")
+    .eq("id", projectId)
+    .maybeSingle();
+
+  if (projectError || !project) {
+    notFound();
+  }
+
+  const [{ data: sprints }, { data: doneStories }] = await Promise.all([
+    supabase
+      .from("sprints")
+      .select("id,name")
+      .eq("project_id", projectId)
+      .order("created_at", { ascending: true }),
+    supabase
+      .from("user_stories")
+      .select("sprint_id,story_points")
+      .eq("project_id", projectId)
+      .eq("status", "done"),
+  ]);
+
+  const velocityData = buildVelocityData(sprints ?? [], doneStories ?? []);
+
+  const totalPoints = velocityData.reduce(
+    (sum, d) => sum + d.completedPoints,
+    0,
+  );
+  const avgVelocity =
+    velocityData.length > 0
+      ? (totalPoints / velocityData.length).toFixed(1)
+      : "—";
+
+  return (
+    <main className="min-h-screen px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto flex w-full max-w-[1540px] flex-col gap-6 lg:flex-row">
+        <div className="lg:w-72 lg:shrink-0">
+          <AppSidebar activeHref="/projects" />
+        </div>
+
+        <div className="min-w-0 flex-1 space-y-6">
+          <Link
+            href={`/projects/${project.id}`}
+            className="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition-colors hover:text-slate-950"
+          >
+            <ArrowLeft className="size-4" />
+            Back to project
+          </Link>
+
+          <header className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6">
+            <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
+              <div className="flex items-start gap-4">
+                <div className="inline-flex size-12 items-center justify-center rounded-2xl bg-slate-950 text-white">
+                  <BarChart3 className="size-6" />
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-brand">
+                    {project.project_key} analytics
+                  </p>
+                  <h1 className="mt-2 font-heading text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                    Sprint velocity
+                  </h1>
+                  <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
+                    Total story points completed per sprint for {project.name}.
+                    Only stories with status Done contribute to the velocity
+                    total.
+                  </p>
+                </div>
+              </div>
+
+              <Button
+                asChild
+                size="lg"
+                className="h-10 rounded-2xl bg-slate-950 px-4 text-white hover:bg-slate-800"
+              >
+                <Link href={`/projects/${project.id}/sprints/new`}>
+                  <Plus className="size-4" />
+                  New sprint
+                </Link>
+              </Button>
+            </div>
+          </header>
+
+          {velocityData.length > 0 && (
+            <section className="grid gap-4 sm:grid-cols-3">
+              {[
+                {
+                  label: "Sprints tracked",
+                  value: String(velocityData.length),
+                },
+                {
+                  label: "Total completed pts",
+                  value: String(totalPoints),
+                },
+                {
+                  label: "Average velocity",
+                  value: avgVelocity,
+                },
+              ].map((item) => (
+                <article
+                  key={item.label}
+                  className="rounded-[1.75rem] border border-white/80 bg-white/88 p-5 shadow-[0_24px_70px_-55px_rgba(15,23,42,0.72)]"
+                >
+                  <p className="text-sm font-medium text-slate-500">
+                    {item.label}
+                  </p>
+                  <p className="mt-2 font-heading text-3xl font-semibold text-slate-950">
+                    {item.value}
+                  </p>
+                </article>
+              ))}
+            </section>
+          )}
+
+          <section className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6">
+            <div className="mb-6">
+              <h2 className="font-heading text-xl font-semibold text-slate-950">
+                Completed story points per sprint
+              </h2>
+              <p className="mt-1 text-sm text-slate-500">
+                {velocityData.length === 0
+                  ? "Create sprints and move stories to Done to start tracking velocity."
+                  : `${velocityData.length} sprint${velocityData.length === 1 ? "" : "s"} tracked`}
+              </p>
+            </div>
+
+            <VelocityChart data={velocityData} />
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(app)/projects/[projectId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import {
   ArrowLeft,
+  BarChart3,
   CalendarDays,
   ClipboardList,
   Columns3,
@@ -204,6 +205,18 @@ export default async function ProjectWorkspacePage({
                   >
                     <ListChecks className="size-4" />
                     AI criteria generator
+                  </Link>
+                </Button>
+                <Button
+                  asChild
+                  size="lg"
+                  className="h-10 rounded-2xl border border-slate-200 bg-white px-4 text-slate-950 hover:bg-slate-50"
+                >
+                  <Link
+                    href={`/projects/${typedProject.id}/analytics/velocity`}
+                  >
+                    <BarChart3 className="size-4" />
+                    Velocity
                   </Link>
                 </Button>
                 <Button

--- a/src/components/charts/velocity-chart.tsx
+++ b/src/components/charts/velocity-chart.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { BarChart3 } from "lucide-react";
+
+import type { VelocityDataPoint } from "@/lib/charts";
+
+type VelocityChartProps = {
+  data: VelocityDataPoint[];
+};
+
+type TooltipPayloadItem = {
+  payload: VelocityDataPoint;
+};
+
+function VelocityTooltip({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: TooltipPayloadItem[];
+}) {
+  if (!active || !payload?.length) return null;
+
+  const point = payload[0]?.payload;
+
+  if (!point) return null;
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white px-3 py-2.5 shadow-md">
+      <p className="text-xs font-semibold text-slate-500">{point.sprintName}</p>
+      <p className="mt-1 font-heading text-lg font-semibold text-slate-950">
+        {point.completedPoints}{" "}
+        <span className="text-sm font-normal text-slate-600">
+          pts completed
+        </span>
+      </p>
+    </div>
+  );
+}
+
+export function VelocityChart({ data }: VelocityChartProps) {
+  const hasData = data.some((d) => d.completedPoints > 0);
+
+  if (!hasData) {
+    return (
+      <div className="flex flex-col items-center justify-center rounded-[1.75rem] border border-dashed border-slate-300 bg-slate-50/80 p-12 text-center">
+        <div className="mx-auto inline-flex size-12 items-center justify-center rounded-2xl bg-brand-soft text-brand">
+          <BarChart3 className="size-6" />
+        </div>
+        <h3 className="mt-4 font-heading text-xl font-semibold text-slate-950">
+          No velocity data yet
+        </h3>
+        <p className="mx-auto mt-2 max-w-sm text-sm leading-6 text-slate-600">
+          Move user stories to Done on the Kanban board to see sprint velocity
+          here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-80">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart
+          data={data}
+          margin={{ top: 8, right: 16, left: 0, bottom: 8 }}
+        >
+          <CartesianGrid
+            strokeDasharray="3 3"
+            stroke="#e2e8f0"
+            vertical={false}
+          />
+          <XAxis
+            dataKey="sprintName"
+            tick={{ fontSize: 12, fill: "#64748b" }}
+            axisLine={false}
+            tickLine={false}
+          />
+          <YAxis
+            tick={{ fontSize: 12, fill: "#64748b" }}
+            axisLine={false}
+            tickLine={false}
+            width={40}
+            allowDecimals={false}
+          />
+          <Tooltip
+            cursor={{ fill: "rgba(14, 165, 233, 0.08)" }}
+            content={<VelocityTooltip />}
+          />
+          <Bar
+            dataKey="completedPoints"
+            fill="#0ea5e9"
+            radius={[6, 6, 0, 0]}
+            maxBarSize={64}
+          />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/lib/charts.ts
+++ b/src/lib/charts.ts
@@ -1,0 +1,26 @@
+export type VelocityDataPoint = {
+  sprintName: string;
+  completedPoints: number;
+};
+
+type SprintRow = {
+  id: string;
+  name: string;
+};
+
+type StoryRow = {
+  sprint_id: string | null;
+  story_points: number | null;
+};
+
+export function buildVelocityData(
+  sprints: SprintRow[],
+  stories: StoryRow[],
+): VelocityDataPoint[] {
+  return sprints.map((sprint) => ({
+    sprintName: sprint.name,
+    completedPoints: stories
+      .filter((s) => s.sprint_id === sprint.id)
+      .reduce((sum, s) => sum + (s.story_points ?? 0), 0),
+  }));
+}


### PR DESCRIPTION
## Summary
Adds a sprint velocity chart to each Minavolve project workspace, 
visualising completed story points per sprint using Recharts.

## Changes
- Added /projects/[projectId]/analytics/velocity page
- Added reusable VelocityChart component (Recharts BarChart)
- Added chart data helper in src/lib/charts.ts
- Summed story_points for Done stories per sprint
- Added sprint name labels on X-axis and story points on Y-axis
- Added hover tooltip
- Added empty state for projects with no Done sprint data
- Added Velocity/Analytics link from project workspace
- Updated README

## Testing
- npm run lint ✓
- npm run dev ✓
- Velocity chart rendered with correct sprint bars ✓
- Only Done stories counted toward velocity ✓
- Sprint names appeared as axis labels ✓
- Empty state displayed when no Done stories exist ✓
- Route protected from logged-out users ✓
- AI generators, Kanban, sprints, and stories still work ✓

Closes #24 