### PR TITLE
feat(charts): add burndown-style sprint chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Minavolve
 
-Minavolve is an Agile sprint board product concept with an AI-assisted backlog workflow. This repository currently ships a polished landing page, Supabase email/password authentication, an authenticated dashboard layout, initial Supabase-backed project/sprint/user story creation and listing, a drag-and-drop Kanban board that persists story status and order, an AI user story generator, an AI acceptance criteria generator, and a sprint velocity chart for project workspaces.
+Minavolve is an Agile sprint board product concept with an AI-assisted backlog workflow. This repository currently ships a polished landing page, Supabase email/password authentication, an authenticated dashboard layout, initial Supabase-backed project/sprint/user story creation and listing, a drag-and-drop Kanban board that persists story status and order, an AI user story generator, an AI acceptance criteria generator, a sprint velocity chart, and a sprint burndown chart for project workspaces.
 
 ## What this issue includes
 
@@ -17,6 +17,7 @@ Minavolve is an Agile sprint board product concept with an AI-assisted backlog w
 - Project-scoped AI user story generator backed by a protected server API route
 - Project-scoped AI acceptance criteria generator backed by a protected server API route
 - Project-scoped sprint velocity chart showing completed story points per sprint
+- Project-scoped sprint burndown chart with ideal and actual lines, sprint selector, and summary tiles
 - Starter environment variable documentation in `.env.example`
 - Initial Supabase schema migration for projects, sprints, stories, risks, AI generations, activity, memberships, and profiles
 
@@ -102,6 +103,7 @@ npm run lint
 - `/projects/[projectId]/ai/story-generator`: protected AI user story generator
 - `/projects/[projectId]/ai/acceptance-criteria`: protected AI acceptance criteria generator
 - `/projects/[projectId]/analytics/velocity`: protected sprint velocity chart
+- `/projects/[projectId]/analytics/burndown`: protected sprint burndown chart
 
 ## Dashboard status
 
@@ -225,6 +227,28 @@ Issue #24 adds a project-scoped sprint velocity chart:
 - No migration is needed — the chart reads from existing `public.sprints` and `public.user_stories` fields.
 
 The chart intentionally does not implement burndown, cumulative flow, or risk analytics.
+
+## Sprint burndown chart status
+
+Issue #26 adds a project-scoped sprint burndown chart:
+
+- `/projects/[projectId]/analytics/burndown` is protected by the existing Supabase server-side user check.
+- All sprints for the project are fetched to populate a sprint selector dropdown in the header.
+- The page defaults to the most recently created sprint when no `sprintId` query param is present.
+- The sprint selector is a `"use client"` component that pushes a `?sprintId=` query param via `useRouter` to switch sprints without a full navigation.
+- Data is aggregated server-side using `buildBurndownData` in `src/lib/charts.ts` — no client-side data fetching.
+- The `BurndownChart` component is a `"use client"` Recharts `LineChart` with two series: Actual (solid blue) and Ideal (dashed grey).
+- The Ideal line is a straight line from total sprint story points on day 1 to zero on the last day of the sprint.
+- The Actual line uses a simplified model: linear interpolation from total points at sprint start to remaining points at the current date (or sprint end if past). Future days are omitted.
+- A custom tooltip shows date, ideal points, and actual points on hover.
+- A legend labels both series.
+- A clear empty state appears when the selected sprint has no start or end date.
+- Summary tiles show total points, remaining points, and completion percentage when the sprint has stories.
+- The burndown page links back to the velocity chart and to the project workspace.
+- The burndown page is linked from the project workspace header as a Burndown button and from the velocity page header.
+- No migration is needed — the chart reads from existing `public.sprints` and `public.user_stories` fields.
+
+The chart intentionally does not implement day-level completion tracking, cumulative flow, or risk analytics.
 
 ## Environment variables
 

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -206,7 +206,7 @@ export default async function DashboardPage() {
                 id="delivery-analytics"
                 eyebrow="Analytics"
                 title="Delivery analytics"
-                description="Sprint velocity charts are available in project workspaces. This dashboard section keeps static KPI tiles."
+                description="Sprint velocity and burndown charts are available in project workspaces. This dashboard section keeps static KPI tiles."
               >
                 <div className="grid gap-3">
                   {analyticsHighlights.map((item) => (

--- a/src/app/(app)/projects/[projectId]/analytics/burndown/page.tsx
+++ b/src/app/(app)/projects/[projectId]/analytics/burndown/page.tsx
@@ -1,0 +1,182 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft, TrendingDown } from "lucide-react";
+import { notFound, redirect } from "next/navigation";
+
+import { AppSidebar } from "@/components/app/app-sidebar";
+import { BurndownChart } from "@/components/charts/burndown-chart";
+import { SprintSelector } from "@/components/charts/sprint-selector";
+import { buildBurndownData } from "@/lib/charts";
+import { createClient } from "@/utils/supabase/server";
+
+export const metadata: Metadata = {
+  title: "Sprint burndown",
+  description: "Sprint burndown chart for a Minavolve project.",
+};
+
+type BurndownPageProps = {
+  params: Promise<{ projectId: string }>;
+  searchParams: Promise<{ sprintId?: string }>;
+};
+
+export default async function BurndownPage({
+  params,
+  searchParams,
+}: BurndownPageProps) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { projectId } = await params;
+  const { sprintId: querySprintId } = await searchParams;
+
+  const { data: project, error: projectError } = await supabase
+    .from("projects")
+    .select("id,name,project_key")
+    .eq("id", projectId)
+    .maybeSingle();
+
+  if (projectError || !project) {
+    notFound();
+  }
+
+  const { data: sprints } = await supabase
+    .from("sprints")
+    .select("id,name,start_date,end_date,status")
+    .eq("project_id", projectId)
+    .order("created_at", { ascending: false });
+
+  const sprintList = sprints ?? [];
+  const selectedSprint =
+    sprintList.find((s) => s.id === querySprintId) ?? sprintList[0] ?? null;
+
+  let stories: Array<{ story_points: number | null; status: string }> = [];
+  if (selectedSprint) {
+    const { data } = await supabase
+      .from("user_stories")
+      .select("story_points,status")
+      .eq("project_id", projectId)
+      .eq("sprint_id", selectedSprint.id);
+    stories = data ?? [];
+  }
+
+  const burndownData = selectedSprint
+    ? buildBurndownData(selectedSprint, stories)
+    : [];
+
+  const totalPoints = stories.reduce(
+    (sum, s) => sum + (s.story_points ?? 0),
+    0,
+  );
+  const donePoints = stories
+    .filter((s) => s.status === "done")
+    .reduce((sum, s) => sum + (s.story_points ?? 0), 0);
+  const remainingPoints = totalPoints - donePoints;
+  const completionPct =
+    totalPoints > 0 ? Math.round((donePoints / totalPoints) * 100) : 0;
+
+  return (
+    <main className="min-h-screen px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto flex w-full max-w-[1540px] flex-col gap-6 lg:flex-row">
+        <div className="lg:w-72 lg:shrink-0">
+          <AppSidebar activeHref="/projects" />
+        </div>
+
+        <div className="min-w-0 flex-1 space-y-6">
+          <Link
+            href={`/projects/${project.id}`}
+            className="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition-colors hover:text-slate-950"
+          >
+            <ArrowLeft className="size-4" />
+            Back to project
+          </Link>
+
+          <header className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6">
+            <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
+              <div className="flex items-start gap-4">
+                <div className="inline-flex size-12 items-center justify-center rounded-2xl bg-slate-950 text-white">
+                  <TrendingDown className="size-6" />
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-brand">
+                    {project.project_key} analytics
+                  </p>
+                  <h1 className="mt-2 font-heading text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                    Sprint burndown
+                  </h1>
+                  <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
+                    Remaining story points over time for {project.name}. The
+                    ideal line assumes steady daily progress from sprint start
+                    to end.
+                  </p>
+                </div>
+              </div>
+
+              {sprintList.length > 0 && (
+                <SprintSelector
+                  sprints={sprintList}
+                  selectedSprintId={selectedSprint?.id ?? null}
+                  projectId={project.id}
+                />
+              )}
+            </div>
+          </header>
+
+          {selectedSprint && stories.length > 0 && (
+            <section className="grid gap-4 sm:grid-cols-3">
+              {[
+                { label: "Total points", value: String(totalPoints) },
+                { label: "Remaining", value: String(remainingPoints) },
+                { label: "Completed", value: `${completionPct}%` },
+              ].map((item) => (
+                <article
+                  key={item.label}
+                  className="rounded-[1.75rem] border border-white/80 bg-white/88 p-5 shadow-[0_24px_70px_-55px_rgba(15,23,42,0.72)]"
+                >
+                  <p className="text-sm font-medium text-slate-500">
+                    {item.label}
+                  </p>
+                  <p className="mt-2 font-heading text-3xl font-semibold text-slate-950">
+                    {item.value}
+                  </p>
+                </article>
+              ))}
+            </section>
+          )}
+
+          <section className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6">
+            <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <h2 className="font-heading text-xl font-semibold text-slate-950">
+                  Remaining points by day
+                </h2>
+                <p className="mt-1 text-sm text-slate-500">
+                  {!selectedSprint
+                    ? "Create sprints to start tracking burndown."
+                    : !selectedSprint.start_date || !selectedSprint.end_date
+                      ? "Add a start date and end date to this sprint to see the burndown chart."
+                      : burndownData.length === 0
+                        ? "Assign story points to stories in this sprint to track burndown."
+                        : `${selectedSprint.name} · simplified burndown`}
+                </p>
+              </div>
+              <Link
+                href={`/projects/${project.id}/analytics/velocity`}
+                className="shrink-0 text-sm font-medium text-brand transition-colors hover:text-brand/80"
+              >
+                View velocity →
+              </Link>
+            </div>
+
+            <BurndownChart data={burndownData} />
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(app)/projects/[projectId]/analytics/velocity/page.tsx
+++ b/src/app/(app)/projects/[projectId]/analytics/velocity/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowLeft, BarChart3, Plus } from "lucide-react";
+import { ArrowLeft, BarChart3, Plus, TrendingDown } from "lucide-react";
 import { notFound, redirect } from "next/navigation";
 
 import { AppSidebar } from "@/components/app/app-sidebar";
@@ -103,16 +103,28 @@ export default async function VelocityPage({ params }: VelocityPageProps) {
                 </div>
               </div>
 
-              <Button
-                asChild
-                size="lg"
-                className="h-10 rounded-2xl bg-slate-950 px-4 text-white hover:bg-slate-800"
-              >
-                <Link href={`/projects/${project.id}/sprints/new`}>
-                  <Plus className="size-4" />
-                  New sprint
-                </Link>
-              </Button>
+              <div className="flex items-center gap-3">
+                <Button
+                  asChild
+                  size="lg"
+                  className="h-10 rounded-2xl border border-slate-200 bg-white px-4 text-slate-950 hover:bg-slate-50"
+                >
+                  <Link href={`/projects/${project.id}/analytics/burndown`}>
+                    <TrendingDown className="size-4" />
+                    Burndown
+                  </Link>
+                </Button>
+                <Button
+                  asChild
+                  size="lg"
+                  className="h-10 rounded-2xl bg-slate-950 px-4 text-white hover:bg-slate-800"
+                >
+                  <Link href={`/projects/${project.id}/sprints/new`}>
+                    <Plus className="size-4" />
+                    New sprint
+                  </Link>
+                </Button>
+              </div>
             </div>
           </header>
 

--- a/src/app/(app)/projects/[projectId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/page.tsx
@@ -14,6 +14,7 @@ import {
   ShieldAlert,
   Sparkles,
   TimerReset,
+  TrendingDown,
 } from "lucide-react";
 import { notFound, redirect } from "next/navigation";
 
@@ -217,6 +218,18 @@ export default async function ProjectWorkspacePage({
                   >
                     <BarChart3 className="size-4" />
                     Velocity
+                  </Link>
+                </Button>
+                <Button
+                  asChild
+                  size="lg"
+                  className="h-10 rounded-2xl border border-slate-200 bg-white px-4 text-slate-950 hover:bg-slate-50"
+                >
+                  <Link
+                    href={`/projects/${typedProject.id}/analytics/burndown`}
+                  >
+                    <TrendingDown className="size-4" />
+                    Burndown
                   </Link>
                 </Button>
                 <Button

--- a/src/components/charts/burndown-chart.tsx
+++ b/src/components/charts/burndown-chart.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { TrendingDown } from "lucide-react";
+
+import type { BurndownDataPoint } from "@/lib/charts";
+
+type BurndownChartProps = {
+  data: BurndownDataPoint[];
+};
+
+type TooltipPayloadItem = {
+  name: string;
+  value: number | null;
+  color: string;
+};
+
+function BurndownTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: TooltipPayloadItem[];
+  label?: string;
+}) {
+  if (!active || !payload?.length) return null;
+
+  const items = payload.filter((item) => item.value != null);
+  if (!items.length) return null;
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white px-3 py-2.5 shadow-md">
+      <p className="text-xs font-semibold text-slate-500">{label}</p>
+      {items.map((item) => (
+        <p
+          key={item.name}
+          className="mt-1 text-sm font-medium"
+          style={{ color: item.color }}
+        >
+          {item.name}:{" "}
+          <span className="font-heading text-base font-semibold text-slate-950">
+            {item.value} pts
+          </span>
+        </p>
+      ))}
+    </div>
+  );
+}
+
+export function BurndownChart({ data }: BurndownChartProps) {
+  if (data.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center rounded-[1.75rem] border border-dashed border-slate-300 bg-slate-50/80 p-12 text-center">
+        <div className="mx-auto inline-flex size-12 items-center justify-center rounded-2xl bg-brand-soft text-brand">
+          <TrendingDown className="size-6" />
+        </div>
+        <h3 className="mt-4 font-heading text-xl font-semibold text-slate-950">
+          No burndown data
+        </h3>
+        <p className="mx-auto mt-2 max-w-sm text-sm leading-6 text-slate-600">
+          Assign story points to stories in this sprint, or pick a sprint with
+          a start and end date.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-80">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart
+          data={data}
+          margin={{ top: 8, right: 16, left: 0, bottom: 8 }}
+        >
+          <CartesianGrid
+            strokeDasharray="3 3"
+            stroke="#e2e8f0"
+            vertical={false}
+          />
+          <XAxis
+            dataKey="date"
+            tick={{ fontSize: 12, fill: "#64748b" }}
+            axisLine={false}
+            tickLine={false}
+            interval="preserveStartEnd"
+          />
+          <YAxis
+            tick={{ fontSize: 12, fill: "#64748b" }}
+            axisLine={false}
+            tickLine={false}
+            width={40}
+            allowDecimals={false}
+          />
+          <Tooltip content={<BurndownTooltip />} />
+          <Legend
+            iconType="line"
+            iconSize={16}
+            wrapperStyle={{ fontSize: "13px", paddingTop: "16px" }}
+          />
+          <Line
+            type="monotone"
+            dataKey="ideal"
+            name="Ideal"
+            stroke="#94a3b8"
+            strokeWidth={2}
+            strokeDasharray="5 5"
+            dot={false}
+          />
+          <Line
+            type="monotone"
+            dataKey="actual"
+            name="Actual"
+            stroke="#0ea5e9"
+            strokeWidth={2}
+            dot={false}
+            connectNulls
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/components/charts/sprint-selector.tsx
+++ b/src/components/charts/sprint-selector.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+type SprintOption = {
+  id: string;
+  name: string;
+};
+
+type SprintSelectorProps = {
+  sprints: SprintOption[];
+  selectedSprintId: string | null;
+  projectId: string;
+};
+
+export function SprintSelector({
+  sprints,
+  selectedSprintId,
+  projectId,
+}: SprintSelectorProps) {
+  const router = useRouter();
+
+  if (sprints.length === 0) return null;
+
+  function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    router.push(
+      `/projects/${projectId}/analytics/burndown?sprintId=${e.target.value}`,
+    );
+  }
+
+  return (
+    <select
+      value={selectedSprintId ?? ""}
+      onChange={handleChange}
+      className="h-10 rounded-2xl border border-slate-200 bg-white px-3 text-sm font-medium text-slate-950 focus:outline-none focus:ring-2 focus:ring-brand"
+    >
+      {sprints.map((sprint) => (
+        <option key={sprint.id} value={sprint.id}>
+          {sprint.name}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/lib/charts.ts
+++ b/src/lib/charts.ts
@@ -24,3 +24,81 @@ export function buildVelocityData(
       .reduce((sum, s) => sum + (s.story_points ?? 0), 0),
   }));
 }
+
+export type BurndownDataPoint = {
+  date: string;
+  ideal: number;
+  actual: number | null;
+};
+
+type SprintForBurndown = {
+  start_date: string | null;
+  end_date: string | null;
+};
+
+type StoryForBurndown = {
+  story_points: number | null;
+  status: string;
+};
+
+export function buildBurndownData(
+  sprint: SprintForBurndown,
+  stories: StoryForBurndown[],
+): BurndownDataPoint[] {
+  if (!sprint.start_date || !sprint.end_date) return [];
+
+  const totalPoints = stories.reduce(
+    (sum, s) => sum + (s.story_points ?? 0),
+    0,
+  );
+  const donePoints = stories
+    .filter((s) => s.status === "done")
+    .reduce((sum, s) => sum + (s.story_points ?? 0), 0);
+  const remainingPoints = totalPoints - donePoints;
+
+  const startDate = new Date(`${sprint.start_date}T00:00:00`);
+  const endDate = new Date(`${sprint.end_date}T00:00:00`);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const totalDays = Math.round(
+    (endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24),
+  );
+
+  if (totalDays <= 0) return [];
+  if (totalPoints === 0) return [];
+
+  const effectiveToday = today > endDate ? endDate : today;
+  const daysElapsed = Math.max(
+    0,
+    Math.round(
+      (effectiveToday.getTime() - startDate.getTime()) /
+        (1000 * 60 * 60 * 24),
+    ),
+  );
+
+  const formatter = new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+  });
+
+  return Array.from({ length: totalDays + 1 }, (_, i) => {
+    const date = new Date(startDate);
+    date.setDate(startDate.getDate() + i);
+
+    const ideal = Math.round(totalPoints - (totalPoints * i) / totalDays);
+
+    let actual: number | null = null;
+    if (i <= daysElapsed) {
+      actual =
+        daysElapsed === 0
+          ? totalPoints
+          : Math.round(
+              totalPoints -
+                ((totalPoints - remainingPoints) * i) / daysElapsed,
+            );
+    }
+
+    return { date: formatter.format(date), ideal, actual };
+  });
+}


### PR DESCRIPTION
## Summary
Adds a sprint burndown chart to Minavolve project analytics, showing
remaining story points day-by-day against an ideal burndown reference line.

## Changes
- Added /projects/[projectId]/analytics/burndown page
- Added reusable BurndownChart component (Recharts LineChart/AreaChart)
- Added burndown data helpers to src/lib/charts.ts
- Plotted Actual remaining points and Ideal reference line
- Added sprint selector to switch between sprints
- Added empty state for sprints with no stories or missing dates
- Added Burndown link from project workspace and velocity chart page
- Updated README

## Testing
- npm run lint ✓
- npm run dev ✓
- Burndown chart rendered with Actual and Ideal lines ✓
- Sprint selector updated chart correctly ✓
- Empty state displayed for sprint with no data ✓
- Route protected from logged-out users ✓
- Velocity chart still works ✓
- AI generators, Kanban, and CRUD flows still work ✓

Closes #26 