### PR TITLE
feat(kanban): filter by priority and sprint

### DIFF
--- a/src/app/(app)/projects/[projectId]/kanban/page.tsx
+++ b/src/app/(app)/projects/[projectId]/kanban/page.tsx
@@ -215,6 +215,10 @@ export default async function ProjectKanbanPage({ params }: KanbanPageProps) {
             <KanbanBoard
               projectId={typedProject.id}
               initialStories={kanbanStories}
+              sprints={((sprints ?? []) as SprintLookup[]).map((s) => ({
+                id: s.id,
+                name: s.name,
+              }))}
             />
           </section>
         </div>

--- a/src/components/kanban/kanban-board.tsx
+++ b/src/components/kanban/kanban-board.tsx
@@ -30,10 +30,14 @@ import {
 } from "@/lib/kanban";
 
 import { KanbanColumn } from "./kanban-column";
+import { KanbanFilters } from "./kanban-filters";
+
+type KanbanSprint = { id: string; name: string };
 
 type KanbanBoardProps = {
   projectId: string;
   initialStories: KanbanStory[];
+  sprints: KanbanSprint[];
 };
 
 type ReorderedBoard = {
@@ -201,7 +205,7 @@ function getPersistedMove(
   };
 }
 
-export function KanbanBoard({ projectId, initialStories }: KanbanBoardProps) {
+export function KanbanBoard({ projectId, initialStories, sprints }: KanbanBoardProps) {
   const router = useRouter();
   const dragStartStoriesRef = useRef<KanbanStory[] | null>(null);
   const [stories, setStories] = useState(initialStories);
@@ -211,6 +215,8 @@ export function KanbanBoard({ projectId, initialStories }: KanbanBoardProps) {
   const [pendingStoryId, setPendingStoryId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [announcement, setAnnouncement] = useState("");
+  const [priorityFilter, setPriorityFilter] = useState("all");
+  const [sprintFilter, setSprintFilter] = useState("all");
   const [isPending, startTransition] = useTransition();
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -227,7 +233,13 @@ export function KanbanBoard({ projectId, initialStories }: KanbanBoardProps) {
       },
     }),
   );
-  const columns = buildKanbanColumns(stories);
+  const filteredStories = stories.filter((story) => {
+    if (priorityFilter !== "all" && story.priority !== priorityFilter) return false;
+    if (sprintFilter !== "all" && story.sprint_id !== sprintFilter) return false;
+    return true;
+  });
+  const allColumns = buildKanbanColumns(stories);
+  const filteredColumns = buildKanbanColumns(filteredStories);
   const movementDisabled = isPending || Boolean(pendingStoryId);
 
   function handleDragStart(event: DragStartEvent) {
@@ -334,7 +346,7 @@ export function KanbanBoard({ projectId, initialStories }: KanbanBoardProps) {
         {announcement}
       </p>
 
-      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <p className="text-sm leading-6 text-slate-600">
           Click a story card to open it, or drag the card between columns to
           update its workflow status.
@@ -345,6 +357,16 @@ export function KanbanBoard({ projectId, initialStories }: KanbanBoardProps) {
           </p>
         ) : null}
       </div>
+
+      <KanbanFilters
+        sprints={sprints}
+        activePriorityFilter={priorityFilter}
+        activeSprintFilter={sprintFilter}
+        onPriorityChange={setPriorityFilter}
+        onSprintChange={setSprintFilter}
+        totalVisible={filteredStories.length}
+        totalCards={stories.length}
+      />
 
       {error ? (
         <div className="mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm leading-6 text-rose-800">
@@ -363,17 +385,24 @@ export function KanbanBoard({ projectId, initialStories }: KanbanBoardProps) {
       >
         <div className="overflow-x-auto pb-3">
           <div className="grid min-w-[1180px] grid-cols-5 gap-4">
-            {columns.map((column) => (
-              <KanbanColumn
-                key={column.status}
-                column={column}
-                disabled={movementDisabled}
-                isDropTarget={
-                  Boolean(activeStory) && activeOverStatus === column.status
-                }
-                pendingStoryId={pendingStoryId}
-              />
-            ))}
+            {filteredColumns.map((filteredColumn, index) => {
+              const allColumn = allColumns[index]!;
+              return (
+                <KanbanColumn
+                  key={filteredColumn.status}
+                  column={filteredColumn}
+                  disabled={movementDisabled}
+                  isDropTarget={
+                    Boolean(activeStory) && activeOverStatus === filteredColumn.status
+                  }
+                  pendingStoryId={pendingStoryId}
+                  isFilteredEmpty={
+                    filteredColumn.stories.length === 0 &&
+                    allColumn.stories.length > 0
+                  }
+                />
+              );
+            })}
           </div>
         </div>
 

--- a/src/components/kanban/kanban-column.tsx
+++ b/src/components/kanban/kanban-column.tsx
@@ -19,6 +19,7 @@ type KanbanColumnProps = {
   disabled?: boolean;
   isDropTarget?: boolean;
   pendingStoryId?: string | null;
+  isFilteredEmpty?: boolean;
 };
 
 export function KanbanColumn({
@@ -26,6 +27,7 @@ export function KanbanColumn({
   disabled = false,
   isDropTarget = false,
   pendingStoryId = null,
+  isFilteredEmpty = false,
 }: KanbanColumnProps) {
   const columnId = getKanbanColumnId(column.status);
   const { isOver, setNodeRef } = useDroppable({
@@ -83,6 +85,10 @@ export function KanbanColumn({
                 isPending={pendingStoryId === story.id}
               />
             ))
+          ) : isFilteredEmpty ? (
+            <p className="px-2 py-8 text-center text-sm leading-6 text-slate-400">
+              No stories match the current filters.
+            </p>
           ) : (
             <div className="rounded-[1.25rem] border border-dashed border-slate-300 bg-white/72 px-4 py-8 text-center text-sm leading-6 text-slate-500">
               {column.emptyState}

--- a/src/components/kanban/kanban-filters.tsx
+++ b/src/components/kanban/kanban-filters.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { ChevronDown, X } from "lucide-react";
+
+import { PRIORITY_ORDER } from "@/lib/kanban";
+
+type KanbanSprint = { id: string; name: string };
+
+type KanbanFiltersProps = {
+  sprints: KanbanSprint[];
+  activePriorityFilter: string;
+  activeSprintFilter: string;
+  onPriorityChange: (value: string) => void;
+  onSprintChange: (value: string) => void;
+  totalVisible: number;
+  totalCards: number;
+};
+
+const priorityLabels: Record<string, string> = {
+  urgent: "Urgent",
+  high: "High",
+  medium: "Medium",
+  low: "Low",
+};
+
+const selectClass =
+  "h-8 w-full appearance-none rounded-xl border border-slate-200 bg-white py-0 pl-3 pr-8 text-sm font-medium text-slate-700 shadow-sm transition-colors hover:border-brand/40 focus:border-brand/50 focus:outline-none focus:ring-2 focus:ring-brand/20 cursor-pointer";
+
+export function KanbanFilters({
+  sprints,
+  activePriorityFilter,
+  activeSprintFilter,
+  onPriorityChange,
+  onSprintChange,
+  totalVisible,
+  totalCards,
+}: KanbanFiltersProps) {
+  const isFiltered =
+    activePriorityFilter !== "all" || activeSprintFilter !== "all";
+
+  return (
+    <div className="mb-4 flex flex-wrap items-center gap-2">
+      <div className="relative">
+        <select
+          className={selectClass}
+          value={activePriorityFilter}
+          onChange={(e) => onPriorityChange(e.target.value)}
+          aria-label="Filter by priority"
+        >
+          <option value="all">All priorities</option>
+          {PRIORITY_ORDER.map((priority) => (
+            <option key={priority} value={priority}>
+              {priorityLabels[priority]}
+            </option>
+          ))}
+        </select>
+        <ChevronDown className="pointer-events-none absolute right-2.5 top-1/2 size-3.5 -translate-y-1/2 text-slate-400" />
+      </div>
+
+      <div className="relative">
+        <select
+          className={selectClass}
+          value={activeSprintFilter}
+          onChange={(e) => onSprintChange(e.target.value)}
+          aria-label="Filter by sprint"
+        >
+          <option value="all">All sprints</option>
+          {sprints.map((sprint) => (
+            <option key={sprint.id} value={sprint.id}>
+              {sprint.name}
+            </option>
+          ))}
+        </select>
+        <ChevronDown className="pointer-events-none absolute right-2.5 top-1/2 size-3.5 -translate-y-1/2 text-slate-400" />
+      </div>
+
+      {isFiltered && (
+        <button
+          type="button"
+          onClick={() => {
+            onPriorityChange("all");
+            onSprintChange("all");
+          }}
+          className="inline-flex h-8 items-center gap-1.5 rounded-xl border border-slate-200 bg-white px-3 text-sm font-medium text-slate-600 shadow-sm transition-colors hover:border-slate-300 hover:bg-slate-50"
+        >
+          <X className="size-3.5" />
+          Clear filters
+        </button>
+      )}
+
+      {totalVisible < totalCards && (
+        <span className="rounded-full bg-brand-soft px-3 py-1 text-xs font-semibold text-brand">
+          Showing {totalVisible} of {totalCards} stories
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/lib/kanban.ts
+++ b/src/lib/kanban.ts
@@ -7,6 +7,13 @@ import {
   ListTodo,
 } from "lucide-react";
 
+export const PRIORITY_ORDER = [
+  "urgent",
+  "high",
+  "medium",
+  "low",
+] as const;
+
 export const kanbanStatuses = [
   "backlog",
   "todo",


### PR DESCRIPTION
## Summary
Adds client-side filter controls to the Kanban board so users can
narrow visible story cards by priority and sprint without a page reload.

## Changes
- Added KanbanFilters component with priority and sprint select controls
- Added priority and sprint filter state to KanbanBoard
- Filters stack with AND logic
- "Showing X of Y stories" badge appears when filters are active
- "Clear filters" button resets both filters to "all"
- KanbanColumn distinguishes between genuinely empty columns and
  filter-emptied columns with different empty state messages
- Drag-and-drop remains fully functional while filters are active
- Server page passes sprints list to KanbanBoard
- README updated

## Testing
- npm run lint ✓
- npm run dev ✓
- Priority filter hides non-matching cards across all columns ✓
- Sprint filter hides cards not in selected sprint ✓
- Both filters active together use AND logic ✓
- Clear filters restores all cards ✓
- Filtered empty state shows correct message per column ✓
- Drag-and-drop works while filters are active ✓
- Story card click navigation still works ✓
- All existing features still work ✓

Closes #34 