### PR TITLE
feat(projects): add project editing

### DIFF
--- a/src/app/(app)/projects/[projectId]/edit/actions.ts
+++ b/src/app/(app)/projects/[projectId]/edit/actions.ts
@@ -1,0 +1,114 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { projectEditSchema } from "@/lib/validators/project";
+import { createClient } from "@/utils/supabase/server";
+
+function getString(formData: FormData, key: string) {
+  const value = formData.get(key);
+  return typeof value === "string" ? value : "";
+}
+
+function getProjectUpdateErrorMessage(message: string) {
+  const normalized = message.toLowerCase();
+
+  if (
+    normalized.includes("start_date") ||
+    normalized.includes("target_end_date")
+  ) {
+    return "Invalid date value. Check the start and end dates and try again.";
+  }
+
+  if (
+    normalized.includes("projects_status_check") ||
+    normalized.includes("violates check constraint")
+  ) {
+    return "The selected status is not supported by the current schema.";
+  }
+
+  if (normalized.includes("duplicate") || normalized.includes("unique")) {
+    return "A project with that name already exists.";
+  }
+
+  if (normalized.includes("row-level security")) {
+    return "Permission denied. Confirm you are signed in and are the project owner.";
+  }
+
+  return "Unable to update project. Check the form and try again.";
+}
+
+export async function updateProject(formData: FormData) {
+  const projectId = getString(formData, "projectId");
+
+  if (!projectId) {
+    redirect("/projects");
+  }
+
+  const parsed = projectEditSchema.safeParse({
+    name: getString(formData, "name"),
+    description: getString(formData, "description"),
+    status: getString(formData, "status"),
+    start_date: getString(formData, "start_date"),
+    target_end_date: getString(formData, "target_end_date"),
+  });
+
+  if (!parsed.success) {
+    redirect(
+      `/projects/${projectId}/edit?error=${encodeURIComponent(
+        parsed.error.issues[0]?.message ?? "Enter valid project details.",
+      )}`,
+    );
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { data: project, error: projectError } = await supabase
+    .from("projects")
+    .select("owner_id")
+    .eq("id", projectId)
+    .maybeSingle();
+
+  if (projectError || !project) {
+    redirect(`/projects/${projectId}/edit?error=${encodeURIComponent("Project not found.")}`);
+  }
+
+  if (project.owner_id !== user.id) {
+    redirect(`/projects/${projectId}?error=not_owner`);
+  }
+
+  const { error } = await supabase
+    .from("projects")
+    .update({
+      name: parsed.data.name,
+      description: parsed.data.description,
+      status: parsed.data.status,
+      start_date: parsed.data.start_date,
+      target_end_date: parsed.data.target_end_date,
+    })
+    .eq("id", projectId);
+
+  if (error) {
+    redirect(
+      `/projects/${projectId}/edit?error=${encodeURIComponent(
+        getProjectUpdateErrorMessage(error.message),
+      )}`,
+    );
+  }
+
+  revalidatePath("/dashboard");
+  revalidatePath("/projects");
+  revalidatePath(`/projects/${projectId}`);
+  revalidatePath(`/projects/${projectId}/edit`);
+  redirect(
+    `/projects/${projectId}?success=${encodeURIComponent("Project updated.")}`,
+  );
+}

--- a/src/app/(app)/projects/[projectId]/edit/page.tsx
+++ b/src/app/(app)/projects/[projectId]/edit/page.tsx
@@ -1,0 +1,128 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft, Pencil } from "lucide-react";
+import { redirect } from "next/navigation";
+
+import { AppNav } from "@/components/app/app-nav";
+import { ProjectForm } from "@/components/projects/project-form";
+import { createClient } from "@/utils/supabase/server";
+
+import { updateProject } from "./actions";
+
+export const metadata: Metadata = {
+  title: "Edit project",
+  description: "Edit project details.",
+};
+
+type EditProjectPageProps = {
+  params: Promise<{
+    projectId: string;
+  }>;
+  searchParams: Promise<{
+    error?: string | string[];
+  }>;
+};
+
+type EditableProject = {
+  id: string;
+  name: string;
+  project_key: string;
+  description: string | null;
+  status: string;
+  start_date: string | null;
+  target_end_date: string | null;
+  owner_id: string;
+};
+
+function getSearchParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export default async function EditProjectPage({
+  params,
+  searchParams,
+}: EditProjectPageProps) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { projectId } = await params;
+  const { data: project, error } = await supabase
+    .from("projects")
+    .select(
+      "id,name,project_key,description,status,start_date,target_end_date,owner_id",
+    )
+    .eq("id", projectId)
+    .maybeSingle();
+
+  if (error || !project) {
+    redirect(`/projects`);
+  }
+
+  const typedProject = project as EditableProject;
+
+  if (typedProject.owner_id !== user.id) {
+    redirect(`/projects/${projectId}`);
+  }
+
+  const query = await searchParams;
+  const editError = getSearchParam(query.error);
+
+  return (
+    <>
+      <AppNav userEmail={user.email ?? ""} />
+      <main className="flex-1 px-4 pb-8 pt-12 sm:px-6 lg:px-8 lg:pt-16">
+        <div className="mx-auto w-full max-w-6xl space-y-6">
+          <Link
+            href={`/projects/${typedProject.id}`}
+            className="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition-colors hover:text-slate-950"
+          >
+            <ArrowLeft className="size-4" />
+            Back to {typedProject.name}
+          </Link>
+
+          <header className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6">
+            <div className="flex items-start gap-4">
+              <div className="inline-flex size-14 items-center justify-center rounded-3xl bg-slate-950 text-white">
+                <Pencil className="size-7" />
+              </div>
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-brand">
+                  Project editing
+                </p>
+                <h1 className="mt-2 font-heading text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                  Edit project
+                </h1>
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  {typedProject.name}
+                  <span className="ml-2 font-mono tracking-[0.1em] text-slate-400">
+                    · {typedProject.project_key}
+                  </span>
+                </p>
+              </div>
+            </div>
+          </header>
+
+          <ProjectForm
+            action={updateProject}
+            editMode
+            projectId={typedProject.id}
+            defaultValues={{
+              name: typedProject.name,
+              description: typedProject.description,
+              status: typedProject.status,
+              start_date: typedProject.start_date,
+              target_end_date: typedProject.target_end_date,
+            }}
+            error={editError}
+          />
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/app/(app)/projects/[projectId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/page.tsx
@@ -9,6 +9,7 @@ import {
   ListChecks,
   MessageSquarePlus,
   MessageSquareText,
+  Pencil,
   Plus,
   ShieldAlert,
   Sparkles,
@@ -40,6 +41,7 @@ type ProjectWorkspacePageProps = {
   }>;
   searchParams: Promise<{
     success?: string | string[];
+    error?: string | string[];
   }>;
 };
 
@@ -51,6 +53,7 @@ type ProjectWorkspace = {
   status: string;
   start_date: string | null;
   target_end_date: string | null;
+  owner_id: string;
   created_at: string;
   updated_at: string;
 };
@@ -117,10 +120,11 @@ export default async function ProjectWorkspacePage({
   const { projectId } = await params;
   const query = await searchParams;
   const success = getSearchParam(query.success);
+  const errorParam = getSearchParam(query.error);
   const { data: project, error } = await supabase
     .from("projects")
     .select(
-      "id,name,project_key,description,status,start_date,target_end_date,created_at,updated_at",
+      "id,name,project_key,description,status,start_date,target_end_date,owner_id,created_at,updated_at",
     )
     .eq("id", projectId)
     .maybeSingle();
@@ -192,24 +196,42 @@ export default async function ProjectWorkspacePage({
             </div>
           )}
 
+          {errorParam === "not_owner" && (
+            <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm leading-6 text-rose-800">
+              Only the project owner can edit this project.
+            </div>
+          )}
+
           <header className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6">
             <div className="flex flex-col gap-5">
-              <div className="flex items-start gap-4">
-                <div className="inline-flex size-14 items-center justify-center rounded-3xl bg-slate-950 font-heading text-sm font-semibold tracking-[0.14em] text-white">
-                  {typedProject.project_key}
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                <div className="flex items-start gap-4">
+                  <div className="inline-flex size-14 shrink-0 items-center justify-center rounded-3xl bg-slate-950 font-heading text-sm font-semibold tracking-[0.14em] text-white">
+                    {typedProject.project_key}
+                  </div>
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-[0.24em] text-brand">
+                      Project workspace
+                    </p>
+                    <h1 className="mt-2 font-heading text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                      {typedProject.name}
+                    </h1>
+                    <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
+                      {typedProject.description ??
+                        "No project description yet. Project editing and richer sprint setup will be implemented in later issues."}
+                    </p>
+                  </div>
                 </div>
-                <div>
-                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-brand">
-                    Project workspace
-                  </p>
-                  <h1 className="mt-2 font-heading text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
-                    {typedProject.name}
-                  </h1>
-                  <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
-                    {typedProject.description ??
-                      "No project description yet. Project editing and richer sprint setup will be implemented in later issues."}
-                  </p>
-                </div>
+
+                {typedProject.owner_id === user.id && (
+                  <Link
+                    href={`/projects/${typedProject.id}/edit`}
+                    className="inline-flex h-10 shrink-0 items-center gap-2 rounded-2xl border border-slate-200 bg-white px-4 text-sm font-semibold text-slate-950 transition-colors hover:bg-slate-50"
+                  >
+                    <Pencil className="size-4" />
+                    Edit project
+                  </Link>
+                )}
               </div>
 
               <div className="flex flex-wrap items-center gap-3">

--- a/src/app/(app)/projects/[projectId]/stories/[storyId]/edit/page.tsx
+++ b/src/app/(app)/projects/[projectId]/stories/[storyId]/edit/page.tsx
@@ -1,0 +1,152 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft, Pencil } from "lucide-react";
+import { redirect } from "next/navigation";
+
+import { AppNav } from "@/components/app/app-nav";
+import {
+  StoryForm,
+  type StorySprintOption,
+} from "@/components/stories/story-form";
+import { createClient } from "@/utils/supabase/server";
+
+export const metadata: Metadata = {
+  title: "Edit story",
+  description: "Edit user story details.",
+};
+
+type EditStoryPageProps = {
+  params: Promise<{
+    projectId: string;
+    storyId: string;
+  }>;
+  searchParams: Promise<{
+    error?: string | string[];
+  }>;
+};
+
+type StoryProject = {
+  id: string;
+  name: string;
+  project_key: string;
+};
+
+type EditableStory = {
+  id: string;
+  project_id: string;
+  sprint_id: string | null;
+  title: string;
+  description: string | null;
+  acceptance_criteria: string[] | null;
+  story_points: number;
+  priority: string;
+  status: string;
+};
+
+function getSearchParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export default async function EditStoryPage({
+  params,
+  searchParams,
+}: EditStoryPageProps) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { projectId, storyId } = await params;
+  const [
+    { data: project, error: projectError },
+    { data: story, error },
+    { data: sprints },
+  ] = await Promise.all([
+    supabase
+      .from("projects")
+      .select("id,name,project_key")
+      .eq("id", projectId)
+      .maybeSingle(),
+    supabase
+      .from("user_stories")
+      .select(
+        "id,project_id,sprint_id,title,description,acceptance_criteria,story_points,priority,status",
+      )
+      .eq("project_id", projectId)
+      .eq("id", storyId)
+      .maybeSingle(),
+    supabase
+      .from("sprints")
+      .select("id,name,status")
+      .eq("project_id", projectId)
+      .order("created_at", { ascending: false }),
+  ]);
+
+  if (projectError || error || !project || !story) {
+    redirect(`/projects`);
+  }
+
+  const typedProject = project as StoryProject;
+  const typedStory = story as EditableStory;
+  const sprintOptions = (sprints ?? []) as StorySprintOption[];
+
+  const query = await searchParams;
+  const editError = getSearchParam(query.error);
+
+  return (
+    <>
+      <AppNav userEmail={user.email ?? ""} />
+      <main className="flex-1 px-4 pb-8 pt-12 sm:px-6 lg:px-8 lg:pt-16">
+        <div className="mx-auto w-full max-w-6xl space-y-6">
+          <Link
+            href={`/projects/${typedProject.id}/stories/${typedStory.id}`}
+            className="inline-flex items-center gap-2 text-sm font-medium text-slate-600 transition-colors hover:text-slate-950"
+          >
+            <ArrowLeft className="size-4" />
+            Back to story
+          </Link>
+
+          <header className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6">
+            <div className="flex items-start gap-4">
+              <div className="inline-flex size-14 shrink-0 items-center justify-center rounded-3xl bg-slate-950 text-white">
+                <Pencil className="size-7" />
+              </div>
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-brand">
+                  {typedProject.project_key} story editing
+                </p>
+                <h1 className="mt-2 font-heading text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                  Edit story
+                </h1>
+                <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
+                  {typedStory.title}
+                </p>
+              </div>
+            </div>
+          </header>
+
+          <StoryForm
+            projectId={typedProject.id}
+            sprints={sprintOptions}
+            error={editError}
+            editMode
+            storyId={typedStory.id}
+            defaultValues={{
+              title: typedStory.title,
+              description: typedStory.description,
+              acceptance_criteria: typedStory.acceptance_criteria,
+              story_points: typedStory.story_points,
+              priority: typedStory.priority,
+              status: typedStory.status,
+              sprint_id: typedStory.sprint_id,
+            }}
+          />
+        </div>
+      </main>
+    </>
+  );
+}

--- a/src/app/(app)/projects/[projectId]/stories/[storyId]/page.tsx
+++ b/src/app/(app)/projects/[projectId]/stories/[storyId]/page.tsx
@@ -14,15 +14,11 @@ import {
 import { notFound, redirect } from "next/navigation";
 
 import { AppNav } from "@/components/app/app-nav";
-import {
-  StoryForm,
-  type StorySprintOption,
-} from "@/components/stories/story-form";
 import { createClient } from "@/utils/supabase/server";
 
 export const metadata: Metadata = {
   title: "Story workspace",
-  description: "Minavolve user story workspace placeholder.",
+  description: "Minavolve user story workspace.",
 };
 
 type StoryDetailPageProps = {
@@ -31,7 +27,6 @@ type StoryDetailPageProps = {
     storyId: string;
   }>;
   searchParams: Promise<{
-    error?: string | string[];
     success?: string | string[];
   }>;
 };
@@ -82,7 +77,6 @@ export default async function StoryDetailPage({
   const [
     { data: project, error: projectError },
     { data: story, error },
-    { data: sprints },
   ] = await Promise.all([
     supabase
       .from("projects")
@@ -97,11 +91,6 @@ export default async function StoryDetailPage({
       .eq("project_id", projectId)
       .eq("id", storyId)
       .maybeSingle(),
-    supabase
-      .from("sprints")
-      .select("id,name,status")
-      .eq("project_id", projectId)
-      .order("created_at", { ascending: false }),
   ]);
 
   if (projectError || error || !project || !story) {
@@ -124,9 +113,7 @@ export default async function StoryDetailPage({
   }
 
   const criteria = typedStory.acceptance_criteria ?? [];
-  const sprintOptions = (sprints ?? []) as StorySprintOption[];
   const query = await searchParams;
-  const editError = getSearchParam(query.error);
   const editSuccess = getSearchParam(query.success);
 
   return (
@@ -151,7 +138,7 @@ export default async function StoryDetailPage({
           <header className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6">
             <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
               <div className="flex items-start gap-4">
-                <div className="inline-flex size-14 items-center justify-center rounded-3xl bg-slate-950 text-white">
+                <div className="inline-flex size-14 shrink-0 items-center justify-center rounded-3xl bg-slate-950 text-white">
                   <MessageSquareText className="size-7" />
                 </div>
                 <div>
@@ -168,9 +155,18 @@ export default async function StoryDetailPage({
                 </div>
               </div>
 
-              <span className="h-fit rounded-full bg-brand-soft px-4 py-2 text-sm font-semibold capitalize text-brand">
-                {typedStory.status.replaceAll("_", " ")}
-              </span>
+              <div className="flex shrink-0 flex-wrap items-center gap-3">
+                <span className="h-fit rounded-full bg-brand-soft px-4 py-2 text-sm font-semibold capitalize text-brand">
+                  {typedStory.status.replaceAll("_", " ")}
+                </span>
+                <Link
+                  href={`/projects/${typedProject.id}/stories/${typedStory.id}/edit`}
+                  className="inline-flex h-10 items-center gap-2 rounded-2xl border border-slate-200 bg-white px-4 text-sm font-semibold text-slate-950 transition-colors hover:bg-slate-50"
+                >
+                  <Pencil className="size-4" />
+                  Edit story
+                </Link>
+              </div>
             </div>
           </header>
 
@@ -252,38 +248,6 @@ export default async function StoryDetailPage({
                 No acceptance criteria were added for this story.
               </p>
             )}
-          </section>
-
-          <section className="space-y-4">
-            <div className="flex items-center gap-3">
-              <div className="inline-flex size-9 items-center justify-center rounded-xl bg-brand-soft text-brand">
-                <Pencil className="size-4" />
-              </div>
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-brand">
-                  Story editing
-                </p>
-                <h2 className="font-heading text-2xl font-semibold text-slate-950">
-                  Edit story
-                </h2>
-              </div>
-            </div>
-            <StoryForm
-              projectId={typedProject.id}
-              sprints={sprintOptions}
-              error={editError}
-              editMode
-              storyId={typedStory.id}
-              defaultValues={{
-                title: typedStory.title,
-                description: typedStory.description,
-                acceptance_criteria: typedStory.acceptance_criteria,
-                story_points: typedStory.story_points,
-                priority: typedStory.priority,
-                status: typedStory.status,
-                sprint_id: typedStory.sprint_id,
-              }}
-            />
           </section>
         </div>
       </main>

--- a/src/app/(app)/projects/[projectId]/stories/actions.ts
+++ b/src/app/(app)/projects/[projectId]/stories/actions.ts
@@ -167,7 +167,7 @@ export async function updateStory(formData: FormData) {
 
   if (!parsed.success) {
     redirect(
-      `/projects/${projectId}/stories/${storyId}?error=${encodeURIComponent(
+      `/projects/${projectId}/stories/${storyId}/edit?error=${encodeURIComponent(
         parsed.error.issues[0]?.message ?? "Enter valid story details.",
       )}`,
     );
@@ -191,7 +191,7 @@ export async function updateStory(formData: FormData) {
 
   if (storyCheckError || !story) {
     redirect(
-      `/projects/${projectId}/stories/${storyId}?error=${encodeURIComponent(
+      `/projects/${projectId}/stories/${storyId}/edit?error=${encodeURIComponent(
         "Story not found or access denied.",
       )}`,
     );
@@ -207,7 +207,7 @@ export async function updateStory(formData: FormData) {
 
     if (sprintError || !sprint) {
       redirect(
-        `/projects/${projectId}/stories/${storyId}?error=${encodeURIComponent(
+        `/projects/${projectId}/stories/${storyId}/edit?error=${encodeURIComponent(
           "Selected sprint does not belong to this project.",
         )}`,
       );
@@ -229,7 +229,7 @@ export async function updateStory(formData: FormData) {
 
   if (error) {
     redirect(
-      `/projects/${projectId}/stories/${storyId}?error=${encodeURIComponent(
+      `/projects/${projectId}/stories/${storyId}/edit?error=${encodeURIComponent(
         getStoryCreateErrorMessage(error.message),
       )}`,
     );

--- a/src/components/projects/project-form.tsx
+++ b/src/components/projects/project-form.tsx
@@ -9,16 +9,38 @@ const statusLabels: Record<(typeof projectStatuses)[number], string> = {
   archived: "Archived",
 };
 
-type ProjectFormProps = {
-  error?: string;
+type ProjectDefaultValues = {
+  name: string;
+  description: string | null;
+  status: string;
+  start_date: string | null;
+  target_end_date: string | null;
 };
 
-export function ProjectForm({ error }: ProjectFormProps) {
+type ProjectFormProps = {
+  error?: string;
+  editMode?: boolean;
+  projectId?: string;
+  defaultValues?: ProjectDefaultValues;
+  action?: (formData: FormData) => void | Promise<void>;
+};
+
+export function ProjectForm({
+  error,
+  editMode = false,
+  projectId,
+  defaultValues,
+  action = createProject,
+}: ProjectFormProps) {
   return (
     <form
-      action={createProject}
+      action={action}
       className="rounded-[2rem] border border-white/80 bg-white/88 p-5 shadow-[0_25px_80px_-55px_rgba(15,23,42,0.72)] backdrop-blur sm:p-6"
     >
+      {editMode && projectId && (
+        <input type="hidden" name="projectId" value={projectId} />
+      )}
+
       {error ? (
         <div className="mb-6 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm leading-6 text-rose-800">
           {error}
@@ -34,32 +56,35 @@ export function ProjectForm({ error }: ProjectFormProps) {
             minLength={3}
             maxLength={120}
             placeholder="Minavolve launch"
+            defaultValue={defaultValues?.name ?? ""}
             className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
           />
         </label>
 
         <div className="grid gap-5 md:grid-cols-2">
-          <label className="block text-sm font-semibold text-slate-800">
-            Project key
-            <input
-              name="project_key"
-              required
-              minLength={2}
-              maxLength={10}
-              pattern="[A-Za-z0-9]{2,10}"
-              placeholder="MINA"
-              className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 font-mono text-sm uppercase tracking-[0.12em] text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
-            />
-            <span className="mt-2 block text-xs font-normal leading-5 text-slate-500">
-              2-10 letters or numbers. The server stores it uppercase.
-            </span>
-          </label>
+          {!editMode && (
+            <label className="block text-sm font-semibold text-slate-800">
+              Project key
+              <input
+                name="project_key"
+                required
+                minLength={2}
+                maxLength={10}
+                pattern="[A-Za-z0-9]{2,10}"
+                placeholder="MINA"
+                className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 font-mono text-sm uppercase tracking-[0.12em] text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
+              />
+              <span className="mt-2 block text-xs font-normal leading-5 text-slate-500">
+                2-10 letters or numbers. The server stores it uppercase.
+              </span>
+            </label>
+          )}
 
           <label className="block text-sm font-semibold text-slate-800">
             Status
             <select
               name="status"
-              defaultValue="active"
+              defaultValue={defaultValues?.status ?? "active"}
               className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
             >
               {projectStatuses.map((status) => (
@@ -78,6 +103,7 @@ export function ProjectForm({ error }: ProjectFormProps) {
             rows={5}
             maxLength={2000}
             placeholder="What is this project trying to deliver?"
+            defaultValue={defaultValues?.description ?? ""}
             className="mt-2 w-full resize-y rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm leading-6 text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
           />
         </label>
@@ -88,6 +114,7 @@ export function ProjectForm({ error }: ProjectFormProps) {
             <input
               name="start_date"
               type="date"
+              defaultValue={defaultValues?.start_date ?? ""}
               className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
             />
           </label>
@@ -97,6 +124,7 @@ export function ProjectForm({ error }: ProjectFormProps) {
             <input
               name="target_end_date"
               type="date"
+              defaultValue={defaultValues?.target_end_date ?? ""}
               className="mt-2 h-12 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 text-sm text-slate-950 outline-none transition focus:border-brand focus:bg-white focus:ring-4 focus:ring-brand/10"
             />
           </label>
@@ -104,15 +132,21 @@ export function ProjectForm({ error }: ProjectFormProps) {
       </div>
 
       <div className="mt-7 flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <p className="text-sm leading-6 text-slate-500">
-          Sprint, story, risk, and AI data will be connected in later issues.
-        </p>
+        {editMode ? (
+          <p className="text-sm leading-6 text-slate-500">
+            Project key cannot be changed after creation.
+          </p>
+        ) : (
+          <p className="text-sm leading-6 text-slate-500">
+            Sprint, story, risk, and AI data will be connected in later issues.
+          </p>
+        )}
         <Button
           type="submit"
           size="lg"
           className="h-11 rounded-2xl bg-slate-950 px-5 text-white hover:bg-slate-800"
         >
-          Create project
+          {editMode ? "Save changes" : "Create project"}
         </Button>
       </div>
     </form>

--- a/src/lib/validators/project.ts
+++ b/src/lib/validators/project.ts
@@ -18,43 +18,56 @@ const optionalDateSchema = z.preprocess((value) => {
   return trimmed.length > 0 ? trimmed : null;
 }, z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Use a valid date.").nullable());
 
-export const projectFormSchema = z
-  .object({
-    name: z
-      .string()
-      .trim()
-      .min(3, "Project name must be at least 3 characters.")
-      .max(120, "Project name must be 120 characters or fewer."),
-    project_key: z
-      .string()
-      .trim()
-      .transform((value) => value.toUpperCase())
-      .refine(
-        (value) => value.length >= 2 && value.length <= 10,
-        "Project key must be 2 to 10 characters.",
-      )
-      .refine(
-        (value) => /^[A-Z0-9]+$/.test(value),
-        "Project key can only use uppercase letters and numbers.",
-      ),
-    description: z
-      .string()
-      .trim()
-      .max(2000, "Description must be 2000 characters or fewer.")
-      .transform((value) => (value.length > 0 ? value : null)),
-    status: z.enum(projectStatuses),
-    start_date: optionalDateSchema,
-    target_end_date: optionalDateSchema,
-  })
-  .refine(
-    (project) =>
-      !project.start_date ||
-      !project.target_end_date ||
-      project.target_end_date >= project.start_date,
-    {
-      message: "Target end date cannot be earlier than start date.",
-      path: ["target_end_date"],
-    },
-  );
+const dateRefinement = (project: {
+  start_date?: string | null;
+  target_end_date?: string | null;
+}) =>
+  !project.start_date ||
+  !project.target_end_date ||
+  project.target_end_date >= project.start_date;
+
+const dateRefinementOptions = {
+  message: "Target end date cannot be earlier than start date.",
+  path: ["target_end_date"],
+};
+
+const projectBaseSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(3, "Project name must be at least 3 characters.")
+    .max(120, "Project name must be 120 characters or fewer."),
+  project_key: z
+    .string()
+    .trim()
+    .transform((value) => value.toUpperCase())
+    .refine(
+      (value) => value.length >= 2 && value.length <= 10,
+      "Project key must be 2 to 10 characters.",
+    )
+    .refine(
+      (value) => /^[A-Z0-9]+$/.test(value),
+      "Project key can only use uppercase letters and numbers.",
+    ),
+  description: z
+    .string()
+    .trim()
+    .max(2000, "Description must be 2000 characters or fewer.")
+    .transform((value) => (value.length > 0 ? value : null)),
+  status: z.enum(projectStatuses),
+  start_date: optionalDateSchema,
+  target_end_date: optionalDateSchema,
+});
+
+export const projectFormSchema = projectBaseSchema.refine(
+  dateRefinement,
+  dateRefinementOptions,
+);
 
 export type ProjectFormValues = z.infer<typeof projectFormSchema>;
+
+export const projectEditSchema = projectBaseSchema
+  .omit({ project_key: true })
+  .refine(dateRefinement, dateRefinementOptions);
+
+export type ProjectEditValues = z.infer<typeof projectEditSchema>;


### PR DESCRIPTION
## Summary
Allows project owners to edit project name, description, status,
and dates from the project workspace. Project key remains immutable
after creation.

## Changes
- Added /projects/[projectId]/edit page with pre-filled form
- Added updateProject server action with ownership check
- Added projectEditSchema (projectFormSchema without project_key)
- Updated ProjectForm to support edit mode with defaultValues
- Added Edit project button to project workspace header
  (visible to project owner only)
- Added ?error=not_owner banner on project workspace
- Added ?success=project_updated banner after successful edit
- Project key shown as read-only display on edit page

## Testing
- npm run lint ✓
- npm run dev ✓
- Edit page loads with all fields pre-filled ✓
- Project name update saves and reflects in header ✓
- Status, description, and dates update correctly ✓
- Date cross-field validation blocks invalid ranges ✓
- Non-owner redirected away from edit page ✓
- Project create flow unchanged ✓
- Sprint activation, story editing, Kanban, AI, charts, risks
  all still work ✓

Closes #36 